### PR TITLE
docs: add generated documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,235 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <title></title>
-  </head>
-  <body>
-    <a href="./packages/align-items">align-items</a>
-  </body>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<title>minions.css</title>
+<style>
+  .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
+  .fs-20p{font-size:20px}
+  .m-0{margin:0}
+  .px-2r{padding-right:2rem;padding-left:2rem}
+</style>
+</head>
+<body class="ff-system-sans fs-20p m-0 px-2r">
+  <h1>minions.css</h1>
+
+  <a href="https://github.com/chantastic/minions.css/" target="_blank">
+    source on Github
+  </a>
+
+  <br />
+  <hr />
+
+  <h2>Packages</h2>
+
+  
+    <p><a href="./packages/align-content">minions.align-content</a></p>
+  
+    <p><a href="./packages/align-items">minions.align-items</a></p>
+  
+    <p><a href="./packages/align-self">minions.align-self</a></p>
+  
+    <p><a href="./packages/animation-delay">minions.animation-delay</a></p>
+  
+    <p><a href="./packages/animation-direction">minions.animation-direction</a></p>
+  
+    <p><a href="./packages/animation-duration">minions.animation-duration</a></p>
+  
+    <p><a href="./packages/animation-iteration-count">minions.animation-iteration-count</a></p>
+  
+    <p><a href="./packages/animation-play-state">minions.animation-play-state</a></p>
+  
+    <p><a href="./packages/animation-timing-function">minions.animation-timing-function</a></p>
+  
+    <p><a href="./packages/background-attachment">minions.background-attachment</a></p>
+  
+    <p><a href="./packages/background-clip">minions.background-clip</a></p>
+  
+    <p><a href="./packages/background-origin">minions.background-origin</a></p>
+  
+    <p><a href="./packages/background-position">minions.background-position</a></p>
+  
+    <p><a href="./packages/background-repeat">minions.background-repeat</a></p>
+  
+    <p><a href="./packages/background-size">minions.background-size</a></p>
+  
+    <p><a href="./packages/border-bottom-width">minions.border-bottom-width</a></p>
+  
+    <p><a href="./packages/border-collapse">minions.border-collapse</a></p>
+  
+    <p><a href="./packages/border-left-width">minions.border-left-width</a></p>
+  
+    <p><a href="./packages/border-radius">minions.border-radius</a></p>
+  
+    <p><a href="./packages/border-right-width">minions.border-right-width</a></p>
+  
+    <p><a href="./packages/border-style">minions.border-style</a></p>
+  
+    <p><a href="./packages/border-top-width">minions.border-top-width</a></p>
+  
+    <p><a href="./packages/border-width">minions.border-width</a></p>
+  
+    <p><a href="./packages/border-x-width">minions.border-x-width</a></p>
+  
+    <p><a href="./packages/border-y-width">minions.border-y-width</a></p>
+  
+    <p><a href="./packages/bottom">minions.bottom</a></p>
+  
+    <p><a href="./packages/box-sizing">minions.box-sizing</a></p>
+  
+    <p><a href="./packages/clear">minions.clear</a></p>
+  
+    <p><a href="./packages/column-count">minions.column-count</a></p>
+  
+    <p><a href="./packages/cursor">minions.cursor</a></p>
+  
+    <p><a href="./packages/display">minions.display</a></p>
+  
+    <p><a href="./packages/flex">minions.flex</a></p>
+  
+    <p><a href="./packages/flex-basis">minions.flex-basis</a></p>
+  
+    <p><a href="./packages/flex-direction">minions.flex-direction</a></p>
+  
+    <p><a href="./packages/flex-flow">minions.flex-flow</a></p>
+  
+    <p><a href="./packages/flex-grow">minions.flex-grow</a></p>
+  
+    <p><a href="./packages/flex-shrink">minions.flex-shrink</a></p>
+  
+    <p><a href="./packages/flex-wrap">minions.flex-wrap</a></p>
+  
+    <p><a href="./packages/float">minions.float</a></p>
+  
+    <p><a href="./packages/font-family">minions.font-family</a></p>
+  
+    <p><a href="./packages/font-style">minions.font-style</a></p>
+  
+    <p><a href="./packages/font-variant">minions.font-variant</a></p>
+  
+    <p><a href="./packages/font-weight">minions.font-weight</a></p>
+  
+    <p><a href="./packages/height">minions.height</a></p>
+  
+    <p><a href="./packages/justify-content">minions.justify-content</a></p>
+  
+    <p><a href="./packages/left">minions.left</a></p>
+  
+    <p><a href="./packages/letter-spacing">minions.letter-spacing</a></p>
+  
+    <p><a href="./packages/line-height">minions.line-height</a></p>
+  
+    <p><a href="./packages/list-style-position">minions.list-style-position</a></p>
+  
+    <p><a href="./packages/list-style-type">minions.list-style-type</a></p>
+  
+    <p><a href="./packages/margin">minions.margin</a></p>
+  
+    <p><a href="./packages/margin-bottom">minions.margin-bottom</a></p>
+  
+    <p><a href="./packages/margin-left">minions.margin-left</a></p>
+  
+    <p><a href="./packages/margin-right">minions.margin-right</a></p>
+  
+    <p><a href="./packages/margin-top">minions.margin-top</a></p>
+  
+    <p><a href="./packages/margin-x">minions.margin-x</a></p>
+  
+    <p><a href="./packages/margin-y">minions.margin-y</a></p>
+  
+    <p><a href="./packages/max-height">minions.max-height</a></p>
+  
+    <p><a href="./packages/max-width">minions.max-width</a></p>
+  
+    <p><a href="./packages/min-height">minions.min-height</a></p>
+  
+    <p><a href="./packages/min-width">minions.min-width</a></p>
+  
+    <p><a href="./packages/mix-blend-mode">minions.mix-blend-mode</a></p>
+  
+    <p><a href="./packages/opacity">minions.opacity</a></p>
+  
+    <p><a href="./packages/outline-style">minions.outline-style</a></p>
+  
+    <p><a href="./packages/outline-width">minions.outline-width</a></p>
+  
+    <p><a href="./packages/overflow">minions.overflow</a></p>
+  
+    <p><a href="./packages/overflow-wrap">minions.overflow-wrap</a></p>
+  
+    <p><a href="./packages/overflow-x">minions.overflow-x</a></p>
+  
+    <p><a href="./packages/overflow-y">minions.overflow-y</a></p>
+  
+    <p><a href="./packages/padding">minions.padding</a></p>
+  
+    <p><a href="./packages/padding-bottom">minions.padding-bottom</a></p>
+  
+    <p><a href="./packages/padding-left">minions.padding-left</a></p>
+  
+    <p><a href="./packages/padding-right">minions.padding-right</a></p>
+  
+    <p><a href="./packages/padding-top">minions.padding-top</a></p>
+  
+    <p><a href="./packages/padding-x">minions.padding-x</a></p>
+  
+    <p><a href="./packages/padding-y">minions.padding-y</a></p>
+  
+    <p><a href="./packages/pointer-events">minions.pointer-events</a></p>
+  
+    <p><a href="./packages/position">minions.position</a></p>
+  
+    <p><a href="./packages/resize">minions.resize</a></p>
+  
+    <p><a href="./packages/right">minions.right</a></p>
+  
+    <p><a href="./packages/text-align">minions.text-align</a></p>
+  
+    <p><a href="./packages/text-decoration">minions.text-decoration</a></p>
+  
+    <p><a href="./packages/text-indent">minions.text-indent</a></p>
+  
+    <p><a href="./packages/text-overflow">minions.text-overflow</a></p>
+  
+    <p><a href="./packages/text-transform">minions.text-transform</a></p>
+  
+    <p><a href="./packages/top">minions.top</a></p>
+  
+    <p><a href="./packages/transition-delay">minions.transition-delay</a></p>
+  
+    <p><a href="./packages/transition-duration">minions.transition-duration</a></p>
+  
+    <p><a href="./packages/transition-property">minions.transition-property</a></p>
+  
+    <p><a href="./packages/transition-timing-function">minions.transition-timing-function</a></p>
+  
+    <p><a href="./packages/vertical-align">minions.vertical-align</a></p>
+  
+    <p><a href="./packages/visibility">minions.visibility</a></p>
+  
+    <p><a href="./packages/white-space">minions.white-space</a></p>
+  
+    <p><a href="./packages/width">minions.width</a></p>
+  
+    <p><a href="./packages/will-change">minions.will-change</a></p>
+  
+    <p><a href="./packages/word-break">minions.word-break</a></p>
+  
+    <p><a href="./packages/word-spacing">minions.word-spacing</a></p>
+  
+    <p><a href="./packages/z-index">minions.z-index</a></p>
+  
+
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-46843279-3', 'auto');
+    ga('send', 'pageview');
+
+  </script>
+</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,13 +6,16 @@
   "style": "minions.min.css",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublish": "node ./scripts/prepublish.js",
     "build": "cleancss --s1 -o minions.min.css _build_all.css"
   },
   "author": "Michael Chan (@chantastic)",
   "repository": "https://github.com/chantastic/minions.css",
   "license": "MIT",
   "dependencies": {
-    "clean-css": "^3.4.9"
+    "clean-css": "^3.4.9",
+    "consolidate": "^0.14.5",
+    "lodash": "^4.17.2"
   },
   "devDependencies": {
     "lerna": "2.0.0-beta.30"

--- a/packages/align-content/README.md
+++ b/packages/align-content/README.md
@@ -1,0 +1,40 @@
+# minions.align-content
+minions align-content classes
+
+## Module
+name: `minions.minions.align-content`  
+version: `0.0.4-alpha-6`  
+main/style: `align-content.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.align-content@0.0.4-alpha-6
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.align-content@0.0.4-alpha-6" />
+```
+
+## Code
+```css
+/*!minions.css*/
+.ac-c{align-items:center}
+.ac-fe{align-items:flex-end}
+.ac-fs{align-items:flex-start}
+.ac-s{align-items:stretch}
+.ac-sb{align-items:space-between}
+.ac-sa{align-items:space-around}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-6/packages/align-content
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/align-content/index.html
+++ b/packages/align-content/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.align-content | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.align-content</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-6/packages/align-content">
     source on Github
   </a>
 
@@ -24,11 +24,12 @@
   <pre>
     <code>
 /*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+.ac-c{align-items:center}
+.ac-fe{align-items:flex-end}
+.ac-fs{align-items:flex-start}
+.ac-s{align-items:stretch}
+.ac-sb{align-items:space-between}
+.ac-sa{align-items:space-around}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.align-content@0.0.4-alpha-6</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-content@0.0.4-alpha-6" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/align-items/README.md
+++ b/packages/align-items/README.md
@@ -1,0 +1,39 @@
+# minions.align-items
+minions align-items classes
+
+## Module
+name: `minions.minions.align-items`  
+version: `0.0.4-alpah-13`  
+main/style: `align-items.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.align-items@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*!minions.css*/
+.ai-b{align-items:baseline}
+.ai-c{align-items:center}
+.ai-fe{align-items:flex-end}
+.ai-fs{align-items:flex-start}
+.ai-s{align-items:stretch}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/align-self/README.md
+++ b/packages/align-self/README.md
@@ -1,0 +1,39 @@
+# minions.align-self
+minions align-self classes
+
+## Module
+name: `minions.minions.align-self`  
+version: `0.0.4-alpha-2`  
+main/style: `align-self.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.align-self@0.0.4-alpha-2
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.align-self@0.0.4-alpha-2" />
+```
+
+## Code
+```css
+/*! minions.css */
+.as-b{align-self:baseline}
+.as-c{align-self:center}
+.as-fe{align-self:flex-end}
+.as-fs{align-self:flex-start}
+.as-s{align-self:stretch}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/align-self
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/align-self/index.html
+++ b/packages/align-self/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.align-self | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.align-self</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/align-self">
     source on Github
   </a>
 
@@ -23,12 +23,12 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.as-b{align-self:baseline}
+.as-c{align-self:center}
+.as-fe{align-self:flex-end}
+.as-fs{align-self:flex-start}
+.as-s{align-self:stretch}
 
     </code>
   </pre>
@@ -37,10 +37,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.align-self@0.0.4-alpha-2</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-self@0.0.4-alpha-2" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/animation-delay/README.md
+++ b/packages/animation-delay/README.md
@@ -1,0 +1,44 @@
+# minions.animation-delay
+minions animation-delay classes
+
+## Module
+name: `minions.minions.animation-delay`  
+version: `0.0.4-alpha-10`  
+main/style: `animation-delay.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.animation-delay@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.animation-delay@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ay-1s{animation-delay:1s}
+.ay-\.9s{animation-delay:.9s}
+.ay-\.8s{animation-delay:.8s}
+.ay-\.7s{animation-delay:.7s}
+.ay-\.6s{animation-delay:.6s}
+.ay-\.5s{animation-delay:.5s}
+.ay-\.4s{animation-delay:.4s}
+.ay-\.3s{animation-delay:.3s}
+.ay-\.2s{animation-delay:.2s}
+.ay-\.1s{animation-delay:.1s}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/animation-delay
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/animation-delay/index.html
+++ b/packages/animation-delay/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.animation-delay | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.animation-delay</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/animation-delay">
     source on Github
   </a>
 
@@ -23,12 +23,17 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ay-1s{animation-delay:1s}
+.ay-\.9s{animation-delay:.9s}
+.ay-\.8s{animation-delay:.8s}
+.ay-\.7s{animation-delay:.7s}
+.ay-\.6s{animation-delay:.6s}
+.ay-\.5s{animation-delay:.5s}
+.ay-\.4s{animation-delay:.4s}
+.ay-\.3s{animation-delay:.3s}
+.ay-\.2s{animation-delay:.2s}
+.ay-\.1s{animation-delay:.1s}
 
     </code>
   </pre>
@@ -37,10 +42,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.animation-delay@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.animation-delay@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/animation-direction/README.md
+++ b/packages/animation-direction/README.md
@@ -1,0 +1,37 @@
+# minions.animation-direction
+minions animation-direction classes
+
+## Module
+name: `minions.minions.animation-direction`  
+version: `0.0.4-alpha-6`  
+main/style: `animation-direction.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.animation-direction@0.0.4-alpha-6
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.animation-direction@0.0.4-alpha-6" />
+```
+
+## Code
+```css
+.ad-n{animation-direction:normal}
+.ad-r{animation-direction:reverse}
+.ad-a{animation-direction:alternate}
+.ad-ar{animation-direction:alternate-reverse}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-6/packages/animation-direction
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/animation-direction/index.html
+++ b/packages/animation-direction/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.animation-direction | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.animation-direction</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-6/packages/animation-direction">
     source on Github
   </a>
 
@@ -23,12 +23,10 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+.ad-n{animation-direction:normal}
+.ad-r{animation-direction:reverse}
+.ad-a{animation-direction:alternate}
+.ad-ar{animation-direction:alternate-reverse}
 
     </code>
   </pre>
@@ -37,10 +35,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.animation-direction@0.0.4-alpha-6</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.animation-direction@0.0.4-alpha-6" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/animation-duration/README.md
+++ b/packages/animation-duration/README.md
@@ -1,0 +1,44 @@
+# minions.animation-duration
+minions animation-duration classes
+
+## Module
+name: `minions.minions.animation-duration`  
+version: `0.0.4-alpha-6`  
+main/style: `animation-duration.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.animation-duration@0.0.4-alpha-6
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.animation-duration@0.0.4-alpha-6" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ad-1s{animation-duration:1s}
+.ad-\.9s{animation-duration:.9s}
+.ad-\.8s{animation-duration:.8s}
+.ad-\.7s{animation-duration:.7s}
+.ad-\.6s{animation-duration:.6s}
+.ad-\.5s{animation-duration:.5s}
+.ad-\.4s{animation-duration:.4s}
+.ad-\.3s{animation-duration:.3s}
+.ad-\.2s{animation-duration:.2s}
+.ad-\.1s{animation-duration:.1s}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-6/packages/animation-duration
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/animation-duration/index.html
+++ b/packages/animation-duration/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.animation-duration | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.animation-duration</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-6/packages/animation-duration">
     source on Github
   </a>
 
@@ -23,12 +23,17 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ad-1s{animation-duration:1s}
+.ad-\.9s{animation-duration:.9s}
+.ad-\.8s{animation-duration:.8s}
+.ad-\.7s{animation-duration:.7s}
+.ad-\.6s{animation-duration:.6s}
+.ad-\.5s{animation-duration:.5s}
+.ad-\.4s{animation-duration:.4s}
+.ad-\.3s{animation-duration:.3s}
+.ad-\.2s{animation-duration:.2s}
+.ad-\.1s{animation-duration:.1s}
 
     </code>
   </pre>
@@ -37,10 +42,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.animation-duration@0.0.4-alpha-6</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.animation-duration@0.0.4-alpha-6" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/animation-iteration-count/README.md
+++ b/packages/animation-iteration-count/README.md
@@ -1,0 +1,38 @@
+# minions.animation-iteration-count
+minions animation-iteration-count classes
+
+## Module
+name: `minions.minions.animation-iteration-count`  
+version: `0.0.4-alpha-6`  
+main/style: `animation-iteration-count.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.animation-iteration-count@0.0.4-alpha-6
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.animation-iteration-count@0.0.4-alpha-6" />
+```
+
+## Code
+```css
+/*! minions.css */
+.atc-i{animation-iteration-count:infinite}
+.atc-1{animation-iteration-count:1}
+.atc-2{animation-iteration-count:2}
+.atc-3{animation-iteration-count:3}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-6/packages/animation-iteration-count
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/animation-iteration-count/index.html
+++ b/packages/animation-iteration-count/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.animation-iteration-count | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.animation-iteration-count</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-6/packages/animation-iteration-count">
     source on Github
   </a>
 
@@ -23,12 +23,11 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.atc-i{animation-iteration-count:infinite}
+.atc-1{animation-iteration-count:1}
+.atc-2{animation-iteration-count:2}
+.atc-3{animation-iteration-count:3}
 
     </code>
   </pre>
@@ -37,10 +36,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.animation-iteration-count@0.0.4-alpha-6</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.animation-iteration-count@0.0.4-alpha-6" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/animation-play-state/README.md
+++ b/packages/animation-play-state/README.md
@@ -1,0 +1,36 @@
+# minions.animation-play-state
+minions animation-play-state classes
+
+## Module
+name: `minions.minions.animation-play-state`  
+version: `0.0.4-alpha-6`  
+main/style: `animation-play-state.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.animation-play-state@0.0.4-alpha-6
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.animation-play-state@0.0.4-alpha-6" />
+```
+
+## Code
+```css
+/*! minions.css */
+.aps-r{animation-play-state: running}
+.aps-p{animation-play-state: paused}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-6/packages/animation-play-state
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/animation-play-state/index.html
+++ b/packages/animation-play-state/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.animation-play-state | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.animation-play-state</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-6/packages/animation-play-state">
     source on Github
   </a>
 
@@ -23,12 +23,9 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.aps-r{animation-play-state: running}
+.aps-p{animation-play-state: paused}
 
     </code>
   </pre>
@@ -37,10 +34,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.animation-play-state@0.0.4-alpha-6</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.animation-play-state@0.0.4-alpha-6" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/animation-timing-function/README.md
+++ b/packages/animation-timing-function/README.md
@@ -1,0 +1,41 @@
+# minions.animation-timing-function
+minions animation-timing-function classes
+
+## Module
+name: `minions.minions.animation-timing-function`  
+version: `0.0.4-alpha-6`  
+main/style: `animation-timing-function.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.animation-timing-function@0.0.4-alpha-6
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.animation-timing-function@0.0.4-alpha-6" />
+```
+
+## Code
+```css
+/*! minions.css */
+.atf-l{animation-timing-function:linear}
+.atf-e{animation-timing-function:ease}
+.atf-ei{animation-timing-function:ease-in}
+.atf-eio{animation-timing-function:ease-in-out}
+.atf-eo{animation-timing-function:ease-out}
+.atf-ss{animation-timing-function:step-start}
+.atf-se{animation-timing-function:step-end}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-6/packages/animation-timing-function
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/animation-timing-function/index.html
+++ b/packages/animation-timing-function/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.animation-timing-function | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.animation-timing-function</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-6/packages/animation-timing-function">
     source on Github
   </a>
 
@@ -23,12 +23,14 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.atf-l{animation-timing-function:linear}
+.atf-e{animation-timing-function:ease}
+.atf-ei{animation-timing-function:ease-in}
+.atf-eio{animation-timing-function:ease-in-out}
+.atf-eo{animation-timing-function:ease-out}
+.atf-ss{animation-timing-function:step-start}
+.atf-se{animation-timing-function:step-end}
 
     </code>
   </pre>
@@ -37,10 +39,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.animation-timing-function@0.0.4-alpha-6</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.animation-timing-function@0.0.4-alpha-6" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/background-attachment/README.md
+++ b/packages/background-attachment/README.md
@@ -1,0 +1,37 @@
+# minions.background-attachment
+minions background-attachment classes
+
+## Module
+name: `minions.minions.background-attachment`  
+version: `0.0.4-alpha-7`  
+main/style: `background-attachment.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.background-attachment@0.0.4-alpha-7
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.background-attachment@0.0.4-alpha-7" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ba-s{background-attachment: scroll}
+.ba-f{background-attachment: fixed}
+.ba-l{background-attachment: local}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/background-attachment
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/background-attachment/index.html
+++ b/packages/background-attachment/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.background-attachment | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.background-attachment</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/background-attachment">
     source on Github
   </a>
 
@@ -23,12 +23,10 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ba-s{background-attachment: scroll}
+.ba-f{background-attachment: fixed}
+.ba-l{background-attachment: local}
 
     </code>
   </pre>
@@ -37,10 +35,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.background-attachment@0.0.4-alpha-7</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.background-attachment@0.0.4-alpha-7" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/background-clip/README.md
+++ b/packages/background-clip/README.md
@@ -1,0 +1,38 @@
+# minions.background-clip
+minions background-clip classes
+
+## Module
+name: `minions.minions.background-clip`  
+version: `0.0.4-alpha-7`  
+main/style: `background-clip.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.background-clip@0.0.4-alpha-7
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.background-clip@0.0.4-alpha-7" />
+```
+
+## Code
+```css
+/*! minions.css */
+.bc-bb{background-clip:border-box}
+.bc-pb{background-clip:padding-box}
+.bc-cb{background-clip:content-box}
+.bc-t{background-clip:text}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/background-clip
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/background-clip/index.html
+++ b/packages/background-clip/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.background-clip | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.background-clip</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/background-clip">
     source on Github
   </a>
 
@@ -23,12 +23,11 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.bc-bb{background-clip:border-box}
+.bc-pb{background-clip:padding-box}
+.bc-cb{background-clip:content-box}
+.bc-t{background-clip:text}
 
     </code>
   </pre>
@@ -37,10 +36,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.background-clip@0.0.4-alpha-7</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.background-clip@0.0.4-alpha-7" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/background-origin/README.md
+++ b/packages/background-origin/README.md
@@ -1,0 +1,37 @@
+# minions.background-origin
+minions background-origin classes
+
+## Module
+name: `minions.minions.background-origin`  
+version: `0.0.4-alpha-7`  
+main/style: `background-origin.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.background-origin@0.0.4-alpha-7
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.background-origin@0.0.4-alpha-7" />
+```
+
+## Code
+```css
+/*! minions.css */
+.bo-bb{background-origin:border-box}
+.bo-pb{background-origin:padding-box}
+.bo-cb{background-origin:content-box}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/background-origin
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/background-origin/index.html
+++ b/packages/background-origin/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.background-origin | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.background-origin</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/background-origin">
     source on Github
   </a>
 
@@ -23,12 +23,10 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.bo-bb{background-origin:border-box}
+.bo-pb{background-origin:padding-box}
+.bo-cb{background-origin:content-box}
 
     </code>
   </pre>
@@ -37,10 +35,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.background-origin@0.0.4-alpha-7</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.background-origin@0.0.4-alpha-7" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/background-position/README.md
+++ b/packages/background-position/README.md
@@ -1,0 +1,39 @@
+# minions.background-position
+minions background-position classes
+
+## Module
+name: `minions.minions.background-position`  
+version: `0.0.4-alpha-7`  
+main/style: `background-position.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.background-position@0.0.4-alpha-7
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.background-position@0.0.4-alpha-7" />
+```
+
+## Code
+```css
+/*! minions.css */
+.bp-t{background-position:top}
+.bp-b{background-position:bottom}
+.bp-l{background-position:left}
+.bp-r{background-position:right}
+.bp-c{background-position:center}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/background-position
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/background-position/index.html
+++ b/packages/background-position/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.background-position | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.background-position</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/background-position">
     source on Github
   </a>
 
@@ -23,12 +23,12 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.bp-t{background-position:top}
+.bp-b{background-position:bottom}
+.bp-l{background-position:left}
+.bp-r{background-position:right}
+.bp-c{background-position:center}
 
     </code>
   </pre>
@@ -37,10 +37,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.background-position@0.0.4-alpha-7</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.background-position@0.0.4-alpha-7" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/background-repeat/README.md
+++ b/packages/background-repeat/README.md
@@ -1,0 +1,39 @@
+# minions.background-repeat
+minions background-repeat classes
+
+## Module
+name: `minions.minions.background-repeat`  
+version: `0.0.4-alpha-7`  
+main/style: `background-repeat.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.background-repeat@0.0.4-alpha-7
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.background-repeat@0.0.4-alpha-7" />
+```
+
+## Code
+```css
+/*! minions.css */
+.br-rx{background-repeat:repeat-x}
+.br-ry{background-repeat:repeat-y}
+.br-r{background-repeat:repeat}
+.br-s{background-repeat:space}
+.br-nr{background-repeat:no-repeat}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/background-repeat
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/background-repeat/index.html
+++ b/packages/background-repeat/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.background-repeat | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.background-repeat</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/background-repeat">
     source on Github
   </a>
 
@@ -23,12 +23,12 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.br-rx{background-repeat:repeat-x}
+.br-ry{background-repeat:repeat-y}
+.br-r{background-repeat:repeat}
+.br-s{background-repeat:space}
+.br-nr{background-repeat:no-repeat}
 
     </code>
   </pre>
@@ -37,10 +37,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.background-repeat@0.0.4-alpha-7</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.background-repeat@0.0.4-alpha-7" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/background-size/README.md
+++ b/packages/background-size/README.md
@@ -1,0 +1,37 @@
+# minions.background-size
+minions background-size classes
+
+## Module
+name: `minions.minions.background-size`  
+version: `0.0.4-alpha-7`  
+main/style: `background-size.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.background-size@0.0.4-alpha-7
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.background-size@0.0.4-alpha-7" />
+```
+
+## Code
+```css
+/*! minions.css */
+.bs-cover{background-size:cover}
+.bs-contain{background-size:contain}
+.bs-a{background-size:auto}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/background-size
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/background-size/index.html
+++ b/packages/background-size/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.background-size | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.background-size</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/background-size">
     source on Github
   </a>
 
@@ -23,12 +23,10 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.bs-cover{background-size:cover}
+.bs-contain{background-size:contain}
+.bs-a{background-size:auto}
 
     </code>
   </pre>
@@ -37,10 +35,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.background-size@0.0.4-alpha-7</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.background-size@0.0.4-alpha-7" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/border-bottom-width/README.md
+++ b/packages/border-bottom-width/README.md
@@ -1,0 +1,40 @@
+# minions.border-bottom-width
+minions border-bottom-width classes
+
+## Module
+name: `minions.minions.border-bottom-width`  
+version: `0.0.4-alpha-2`  
+main/style: `border-bottom-width.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.border-bottom-width@0.0.4-alpha-2
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.border-bottom-width@0.0.4-alpha-2" />
+```
+
+## Code
+```css
+/*! minions.css */
+.bbw-0,.bbw-1p,.bbw-2p,.bbw-3p,.bbw-4p{border-style:solid}
+.bbw-0{border-bottom-width:0}
+.bbw-1p{border-bottom-width:1px}
+.bbw-2p{border-bottom-width:2px}
+.bbw-3p{border-bottom-width:3px}
+.bbw-4p{border-bottom-width:4px}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-bottom-width
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/border-bottom-width/index.html
+++ b/packages/border-bottom-width/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.border-bottom-width | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.border-bottom-width</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-bottom-width">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.bbw-0,.bbw-1p,.bbw-2p,.bbw-3p,.bbw-4p{border-style:solid}
+.bbw-0{border-bottom-width:0}
+.bbw-1p{border-bottom-width:1px}
+.bbw-2p{border-bottom-width:2px}
+.bbw-3p{border-bottom-width:3px}
+.bbw-4p{border-bottom-width:4px}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.border-bottom-width@0.0.4-alpha-2</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.border-bottom-width@0.0.4-alpha-2" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/border-collapse/README.md
+++ b/packages/border-collapse/README.md
@@ -1,0 +1,36 @@
+# minions.border-collapse
+minions border-collapse classes
+
+## Module
+name: `minions.minions.border-collapse`  
+version: `0.0.4-alpha-14`  
+main/style: `border-collapse.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.border-collapse@0.0.4-alpha-14
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.border-collapse@0.0.4-alpha-14" />
+```
+
+## Code
+```css
+/* minions.css */
+.bc-c{border-collapse:collapse}
+.bc-s{border-collapse:separate}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/border-collapse
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/border-collapse/index.html
+++ b/packages/border-collapse/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.border-collapse | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.border-collapse</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/border-collapse">
     source on Github
   </a>
 
@@ -23,12 +23,9 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/* minions.css */
+.bc-c{border-collapse:collapse}
+.bc-s{border-collapse:separate}
 
     </code>
   </pre>
@@ -37,10 +34,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.border-collapse@0.0.4-alpha-14</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.border-collapse@0.0.4-alpha-14" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/border-left-width/README.md
+++ b/packages/border-left-width/README.md
@@ -1,0 +1,40 @@
+# minions.border-left-width
+minions border-left-width classes
+
+## Module
+name: `minions.minions.border-left-width`  
+version: `0.0.4-alpha-2`  
+main/style: `border-left-width.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.border-left-width@0.0.4-alpha-2
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.border-left-width@0.0.4-alpha-2" />
+```
+
+## Code
+```css
+/*! minions.css */
+.blw-0,.blw-1p,.blw-2p,.blw-3p,.blw-4p{border-style:solid}
+.blw-0{border-left-width:0}
+.blw-1p{border-left-width:1px}
+.blw-2p{border-left-width:2px}
+.blw-3p{border-left-width:3px}
+.blw-4p{border-left-width:4px}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-left-width
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/border-left-width/index.html
+++ b/packages/border-left-width/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.border-left-width | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.border-left-width</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-left-width">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.blw-0,.blw-1p,.blw-2p,.blw-3p,.blw-4p{border-style:solid}
+.blw-0{border-left-width:0}
+.blw-1p{border-left-width:1px}
+.blw-2p{border-left-width:2px}
+.blw-3p{border-left-width:3px}
+.blw-4p{border-left-width:4px}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.border-left-width@0.0.4-alpha-2</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.border-left-width@0.0.4-alpha-2" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/border-radius/README.md
+++ b/packages/border-radius/README.md
@@ -1,0 +1,39 @@
+# minions.border-radius
+minions border-radius classes
+
+## Module
+name: `minions.minions.border-radius`  
+version: `0.0.4-alpha-12`  
+main/style: `border-radius.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.border-radius@0.0.4-alpha-12
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.border-radius@0.0.4-alpha-12" />
+```
+
+## Code
+```css
+/*! minions.css */
+.br-0{border-radius:0}
+.br-1p{border-radius:1px}
+.br-2p{border-radius:2px}
+.br-3p{border-radius:3px}
+.br-4p{border-radius:4px}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-12/packages/border-radius
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/border-radius/index.html
+++ b/packages/border-radius/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.border-radius | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.border-radius</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-12/packages/border-radius">
     source on Github
   </a>
 
@@ -23,12 +23,12 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.br-0{border-radius:0}
+.br-1p{border-radius:1px}
+.br-2p{border-radius:2px}
+.br-3p{border-radius:3px}
+.br-4p{border-radius:4px}
 
     </code>
   </pre>
@@ -37,10 +37,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.border-radius@0.0.4-alpha-12</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.border-radius@0.0.4-alpha-12" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/border-right-width/README.md
+++ b/packages/border-right-width/README.md
@@ -1,0 +1,40 @@
+# minions.border-right-width
+minions border-right-width classes
+
+## Module
+name: `minions.minions.border-right-width`  
+version: `0.0.4-alpha-2`  
+main/style: `border-right-width.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.border-right-width@0.0.4-alpha-2
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.border-right-width@0.0.4-alpha-2" />
+```
+
+## Code
+```css
+/*! minions.css */
+.brw-0,.brw-1p,.brw-2p,.brw-3p,.brw-4p{border-style:solid}
+.brw-0{border-right-width:0}
+.brw-1p{border-right-width:1px}
+.brw-2p{border-right-width:2px}
+.brw-3p{border-right-width:3px}
+.brw-4p{border-right-width:4px}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-right-width
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/border-right-width/index.html
+++ b/packages/border-right-width/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.border-right-width | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.border-right-width</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-right-width">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.brw-0,.brw-1p,.brw-2p,.brw-3p,.brw-4p{border-style:solid}
+.brw-0{border-right-width:0}
+.brw-1p{border-right-width:1px}
+.brw-2p{border-right-width:2px}
+.brw-3p{border-right-width:3px}
+.brw-4p{border-right-width:4px}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.border-right-width@0.0.4-alpha-2</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.border-right-width@0.0.4-alpha-2" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/border-style/README.md
+++ b/packages/border-style/README.md
@@ -1,0 +1,41 @@
+# minions.border-style
+minions border-style classes
+
+## Module
+name: `minions.minions.border-style`  
+version: `0.0.4-alpha-10`  
+main/style: `border-style.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.border-style@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.border-style@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.bs-a{border-style:auto}
+.bs-d{border-style:dotted}
+.bs-n{border-style:none}
+.bs-s{border-style:solid}
+.bs-t{border-style:thin}
+.bs-m{border-style:medium}
+.bs-k{border-style:thick}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/border-style
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/border-style/index.html
+++ b/packages/border-style/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.border-style | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.border-style</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/border-style">
     source on Github
   </a>
 
@@ -23,12 +23,14 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.bs-a{border-style:auto}
+.bs-d{border-style:dotted}
+.bs-n{border-style:none}
+.bs-s{border-style:solid}
+.bs-t{border-style:thin}
+.bs-m{border-style:medium}
+.bs-k{border-style:thick}
 
     </code>
   </pre>
@@ -37,10 +39,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.border-style@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.border-style@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/border-top-width/README.md
+++ b/packages/border-top-width/README.md
@@ -1,0 +1,40 @@
+# minions.border-top-width
+minions border-top-width classes
+
+## Module
+name: `minions.minions.border-top-width`  
+version: `0.0.4-alpha-2`  
+main/style: `border-top-width.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.border-top-width@0.0.4-alpha-2
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.border-top-width@0.0.4-alpha-2" />
+```
+
+## Code
+```css
+/*! minions.css */
+.btw-0,.btw-1p,.btw-2p,.btw-3p,.btw-4p{border-style:solid}
+.btw-0{border-top-width:0}
+.btw-1p{border-top-width:1px}
+.btw-2p{border-top-width:2px}
+.btw-3p{border-top-width:3px}
+.btw-4p{border-top-width:4px}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-top-width
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/border-top-width/index.html
+++ b/packages/border-top-width/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.border-top-width | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.border-top-width</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-top-width">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.btw-0,.btw-1p,.btw-2p,.btw-3p,.btw-4p{border-style:solid}
+.btw-0{border-top-width:0}
+.btw-1p{border-top-width:1px}
+.btw-2p{border-top-width:2px}
+.btw-3p{border-top-width:3px}
+.btw-4p{border-top-width:4px}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.border-top-width@0.0.4-alpha-2</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.border-top-width@0.0.4-alpha-2" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/border-width/README.md
+++ b/packages/border-width/README.md
@@ -1,0 +1,40 @@
+# minions.border-width
+minions border-width classes
+
+## Module
+name: `minions.minions.border-width`  
+version: `0.0.4-alpha-2`  
+main/style: `border-width.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.border-width@0.0.4-alpha-2
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.border-width@0.0.4-alpha-2" />
+```
+
+## Code
+```css
+/*! minions.css */
+.bw-0,.bw-1p,.bw-2p,.bw-3p,.bw-4p{border-style:solid}
+.bw-0{border-width:0}
+.bw-1p{border-width:1px}
+.bw-2p{border-width:2px}
+.bw-3p{border-width:3px}
+.bw-4p{border-width:4px}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-width
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/border-width/index.html
+++ b/packages/border-width/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.border-width | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.border-width</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-width">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.bw-0,.bw-1p,.bw-2p,.bw-3p,.bw-4p{border-style:solid}
+.bw-0{border-width:0}
+.bw-1p{border-width:1px}
+.bw-2p{border-width:2px}
+.bw-3p{border-width:3px}
+.bw-4p{border-width:4px}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.border-width@0.0.4-alpha-2</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.border-width@0.0.4-alpha-2" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/border-x-width/README.md
+++ b/packages/border-x-width/README.md
@@ -1,0 +1,39 @@
+# minions.border-x-width
+minions border-x-width classes
+
+## Module
+name: `minions.minions.border-x-width`  
+version: `0.0.4-alpha-2`  
+main/style: `border-x-width.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.border-x-width@0.0.4-alpha-2
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.border-x-width@0.0.4-alpha-2" />
+```
+
+## Code
+```css
+/*! minions.css */
+.bxw-0{border-right-width:0;border-left-width:0}
+.bxw-1p{border-right-width:1px;border-left-width:1px}
+.bxw-2p{border-right-width:2px;border-left-width:2px}
+.bxw-3p{border-right-width:3px;border-left-width:3px}
+.bxw-4p{border-right-width:4px;border-left-width:4px}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-x-width
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/border-x-width/index.html
+++ b/packages/border-x-width/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.border-x-width | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.border-x-width</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-x-width">
     source on Github
   </a>
 
@@ -23,12 +23,12 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.bxw-0{border-right-width:0;border-left-width:0}
+.bxw-1p{border-right-width:1px;border-left-width:1px}
+.bxw-2p{border-right-width:2px;border-left-width:2px}
+.bxw-3p{border-right-width:3px;border-left-width:3px}
+.bxw-4p{border-right-width:4px;border-left-width:4px}
 
     </code>
   </pre>
@@ -37,10 +37,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.border-x-width@0.0.4-alpha-2</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.border-x-width@0.0.4-alpha-2" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/border-y-width/README.md
+++ b/packages/border-y-width/README.md
@@ -1,0 +1,40 @@
+# minions.border-y-width
+minions border-y-width classes
+
+## Module
+name: `minions.minions.border-y-width`  
+version: `0.0.4-alpha-2`  
+main/style: `border-y-width.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.border-y-width@0.0.4-alpha-2
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.border-y-width@0.0.4-alpha-2" />
+```
+
+## Code
+```css
+/*! minions.css */
+.byw-0,.byw-1p,.byw-2p,.byw-3p,.byw-4p{border-style:solid}
+.byw-0{border-top-width:0;border-bottom-width:0}
+.byw-1p{border-top-width:1px;border-bottom-width:1px}
+.byw-2p{border-top-width:2px;border-bottom-width:2px}
+.byw-3p{border-top-width:3px;border-bottom-width:3px}
+.byw-4p{border-top-width:4px;border-bottom-width:4px}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-y-width
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/border-y-width/index.html
+++ b/packages/border-y-width/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.border-y-width | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.border-y-width</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-2/packages/border-y-width">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.byw-0,.byw-1p,.byw-2p,.byw-3p,.byw-4p{border-style:solid}
+.byw-0{border-top-width:0;border-bottom-width:0}
+.byw-1p{border-top-width:1px;border-bottom-width:1px}
+.byw-2p{border-top-width:2px;border-bottom-width:2px}
+.byw-3p{border-top-width:3px;border-bottom-width:3px}
+.byw-4p{border-top-width:4px;border-bottom-width:4px}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.border-y-width@0.0.4-alpha-2</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.border-y-width@0.0.4-alpha-2" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/bottom/README.md
+++ b/packages/bottom/README.md
@@ -1,0 +1,51 @@
+# minions.bottom
+minions bottom classes
+
+## Module
+name: `minions.minions.bottom`  
+version: `0.0.4-alpha-3`  
+main/style: `bottom.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.bottom@0.0.4-alpha-3
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.bottom@0.0.4-alpha-3" />
+```
+
+## Code
+```css
+/*! minions.css */
+.b-0{bottom:0}
+.b-1p{bottom:1px}
+.b-2p{bottom:1px}
+.b-3p{bottom:3px}
+.b-4p{bottom:4px}
+.b-\.25e{bottom:.25em}
+.b-\.5e{bottom:.5em}
+.b-1e{bottom:1em}
+.b-2e{bottom:2em}
+.b-3e{bottom:3em}
+.b-4e{bottom:4em}
+.b-\.25r{bottom:.25em}
+.b-\.5r{bottom:.5em}
+.b-1r{bottom:1em}
+.b-2r{bottom:2em}
+.b-3r{bottom:3em}
+.b-4r{bottom:4em}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/bottom
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/bottom/index.html
+++ b/packages/bottom/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.bottom | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.bottom</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/bottom">
     source on Github
   </a>
 
@@ -23,12 +23,24 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.b-0{bottom:0}
+.b-1p{bottom:1px}
+.b-2p{bottom:1px}
+.b-3p{bottom:3px}
+.b-4p{bottom:4px}
+.b-\.25e{bottom:.25em}
+.b-\.5e{bottom:.5em}
+.b-1e{bottom:1em}
+.b-2e{bottom:2em}
+.b-3e{bottom:3em}
+.b-4e{bottom:4em}
+.b-\.25r{bottom:.25em}
+.b-\.5r{bottom:.5em}
+.b-1r{bottom:1em}
+.b-2r{bottom:2em}
+.b-3r{bottom:3em}
+.b-4r{bottom:4em}
 
     </code>
   </pre>
@@ -37,10 +49,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.bottom@0.0.4-alpha-3</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.bottom@0.0.4-alpha-3" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/box-sizing/README.md
+++ b/packages/box-sizing/README.md
@@ -1,0 +1,36 @@
+# minions.box-sizing
+minions box-sizing classes
+
+## Module
+name: `minions.minions.box-sizing`  
+version: `0.0.4-alpha-11`  
+main/style: `box-sizing.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.box-sizing@0.0.4-alpha-11
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.box-sizing@0.0.4-alpha-11" />
+```
+
+## Code
+```css
+/*! minions.css */
+.bs-cb{box-sizing:content-box}
+.bs-bb{box-sizing:border-box}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-11/packages/box-sizing
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/box-sizing/index.html
+++ b/packages/box-sizing/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.box-sizing | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.box-sizing</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-11/packages/box-sizing">
     source on Github
   </a>
 
@@ -23,12 +23,9 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.bs-cb{box-sizing:content-box}
+.bs-bb{box-sizing:border-box}
 
     </code>
   </pre>
@@ -37,10 +34,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.box-sizing@0.0.4-alpha-11</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.box-sizing@0.0.4-alpha-11" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/clear/README.md
+++ b/packages/clear/README.md
@@ -1,0 +1,38 @@
+# minions.clear
+minions clear classes
+
+## Module
+name: `minions.minions.clear`  
+version: `0.0.4-alpha-7`  
+main/style: `clear.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.clear@0.0.4-alpha-7
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.clear@0.0.4-alpha-7" />
+```
+
+## Code
+```css
+/*! minions.css */
+.c-n{clear:none}
+.c-l{clear:left}
+.c-r{clear:right}
+.c-b{clear:both}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/clear
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/clear/index.html
+++ b/packages/clear/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.clear | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.clear</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/clear">
     source on Github
   </a>
 
@@ -23,12 +23,11 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.c-n{clear:none}
+.c-l{clear:left}
+.c-r{clear:right}
+.c-b{clear:both}
 
     </code>
   </pre>
@@ -37,10 +36,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.clear@0.0.4-alpha-7</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.clear@0.0.4-alpha-7" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/column-count/README.md
+++ b/packages/column-count/README.md
@@ -1,0 +1,38 @@
+# minions.column-count
+minions column-count classes
+
+## Module
+name: `minions.minions.column-count`  
+version: `0.0.4-alpha-7`  
+main/style: `column-count.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.column-count@0.0.4-alpha-7
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.column-count@0.0.4-alpha-7" />
+```
+
+## Code
+```css
+/*! minions.css */
+.cc-a{column-count:auto}
+.cc-1{column-count:1}
+.cc-2{column-count:2}
+.cc-3{column-count:3}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/column-count
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/column-count/index.html
+++ b/packages/column-count/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.column-count | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.column-count</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-7/packages/column-count">
     source on Github
   </a>
 
@@ -23,12 +23,11 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.cc-a{column-count:auto}
+.cc-1{column-count:1}
+.cc-2{column-count:2}
+.cc-3{column-count:3}
 
     </code>
   </pre>
@@ -37,10 +36,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.column-count@0.0.4-alpha-7</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.column-count@0.0.4-alpha-7" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/cursor/README.md
+++ b/packages/cursor/README.md
@@ -1,0 +1,62 @@
+# minions.cursor
+minions cursor classes
+
+## Module
+name: `minions.minions.cursor`  
+version: `0.0.4-alpha-5`  
+main/style: `cursor.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.cursor@0.0.4-alpha-5
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.cursor@0.0.4-alpha-5" />
+```
+
+## Code
+```css
+/*! minions.css */
+.c-a{cursor:auto}
+.c-d{cursor:default}
+.c-n{cursor:none}
+.c-cm{cursor:context-menu}
+.c-h{cursor:help}
+.c-p{cursor:pointer}
+.c-s{cursor:progress}
+.c-w{cursor:wait}
+.c-c{cursor:cell}
+.c-r{cursor:crosshair}
+.c-t{cursor:text}
+.c-vt{cursor:vertical-text}
+.c-m{cursor:move}
+.c-nd{cursor:no-drop}
+.c-na{cursor:not-allowed}
+.c-as{cursor:all-scroll}
+.c-cr{cursor:col-resize}
+.c-rr{cursor:row-resize}
+.c-nr{cursor:n-resize}
+.c-er{cursor:e-resize}
+.c-sr{cursor:s-resize}
+.c-wr{cursor:w-resize}
+.c-zi{cursor:-webkit-zoom-in;cursor:zoom-in}
+.c-zo{cursor:-webkit-zoom-out;cursor:zoom-out}
+.c-g{cursor:-moz-grab;cursor:-webkit-grab;cursor:grab}
+.c-b{cursor:-moz-grabbing;cursor:-webkit-grabbing;cursor:grabbing}
+.c-i{cursor:initial}
+.c-u{cursor:unset}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-5/packages/cursor
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/cursor/index.html
+++ b/packages/cursor/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>minions.cursor | minions.css</title>
+  <style>
+    .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
+    .fs-20p{font-size:20px}
+    .m-0{margin:0}
+    .px-2r{padding-right:2rem;padding-left:2rem}
+  </style>
+</head>
+<body class="ff-system-sans fs-20p m-0 px-2r">
+  <h1>minions.cursor</h1>
+
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-5/packages/cursor">
+    source on Github
+  </a>
+
+  <br />
+  <hr />
+
+  <pre>
+    <code>
+/*! minions.css */
+.c-a{cursor:auto}
+.c-d{cursor:default}
+.c-n{cursor:none}
+.c-cm{cursor:context-menu}
+.c-h{cursor:help}
+.c-p{cursor:pointer}
+.c-s{cursor:progress}
+.c-w{cursor:wait}
+.c-c{cursor:cell}
+.c-r{cursor:crosshair}
+.c-t{cursor:text}
+.c-vt{cursor:vertical-text}
+.c-m{cursor:move}
+.c-nd{cursor:no-drop}
+.c-na{cursor:not-allowed}
+.c-as{cursor:all-scroll}
+.c-cr{cursor:col-resize}
+.c-rr{cursor:row-resize}
+.c-nr{cursor:n-resize}
+.c-er{cursor:e-resize}
+.c-sr{cursor:s-resize}
+.c-wr{cursor:w-resize}
+.c-zi{cursor:-webkit-zoom-in;cursor:zoom-in}
+.c-zo{cursor:-webkit-zoom-out;cursor:zoom-out}
+.c-g{cursor:-moz-grab;cursor:-webkit-grab;cursor:grab}
+.c-b{cursor:-moz-grabbing;cursor:-webkit-grabbing;cursor:grabbing}
+.c-i{cursor:initial}
+.c-u{cursor:unset}
+
+    </code>
+  </pre>
+
+  <hr />
+
+  <h2>Installation</h2>
+  <h4>npm</h4>
+  <code>npm install minions.cursor@0.0.4-alpha-5</code>
+
+  <h4>browser</h4>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.cursor@0.0.4-alpha-5" /&gt;</code>
+
+  <h2>License</h2>
+  <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>
+
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-46843279-3', 'auto');
+    ga('send', 'pageview');
+
+  </script>
+</body>
+</html>

--- a/packages/display/README.md
+++ b/packages/display/README.md
@@ -1,0 +1,42 @@
+# minions.display
+minions display classes
+
+## Module
+name: `minions.minions.display`  
+version: `0.0.4-alpha-3`  
+main/style: `display.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.display@0.0.4-alpha-3
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.display@0.0.4-alpha-3" />
+```
+
+## Code
+```css
+/*! minions.css */
+.d-b{display:block}
+.d-i{display:inline}
+.d-ib{display:inline-block}
+.d-n{display:none}
+.d-f{display:flex}
+.d-t{display:table}
+.d-tc{display:table-cell}
+.d-tr{display:table-row}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/display
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/display/index.html
+++ b/packages/display/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.display | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.display</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/display">
     source on Github
   </a>
 
@@ -23,12 +23,15 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.d-b{display:block}
+.d-i{display:inline}
+.d-ib{display:inline-block}
+.d-n{display:none}
+.d-f{display:flex}
+.d-t{display:table}
+.d-tc{display:table-cell}
+.d-tr{display:table-row}
 
     </code>
   </pre>
@@ -37,10 +40,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.display@0.0.4-alpha-3</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.display@0.0.4-alpha-3" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/flex-basis/README.md
+++ b/packages/flex-basis/README.md
@@ -1,0 +1,35 @@
+# minions.flex-basis
+minions flex-basis classes
+
+## Module
+name: `minions.minions.flex-basis`  
+version: `0.0.4-alpha-3`  
+main/style: `flex-basis.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.flex-basis@0.0.4-alpha-3
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.flex-basis@0.0.4-alpha-3" />
+```
+
+## Code
+```css
+/*! minions.css */
+.fb-0{flex-basis:0}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/flex-basis
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/flex-basis/index.html
+++ b/packages/flex-basis/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.flex-basis | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.flex-basis</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/flex-basis">
     source on Github
   </a>
 
@@ -23,12 +23,8 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.fb-0{flex-basis:0}
 
     </code>
   </pre>
@@ -37,10 +33,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.flex-basis@0.0.4-alpha-3</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.flex-basis@0.0.4-alpha-3" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/flex-direction/README.md
+++ b/packages/flex-direction/README.md
@@ -1,0 +1,36 @@
+# minions.flex-direction
+minions flex-direction classes
+
+## Module
+name: `minions.minions.flex-direction`  
+version: `0.0.4-alpha-3`  
+main/style: `flex-direction.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.flex-direction@0.0.4-alpha-3
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.flex-direction@0.0.4-alpha-3" />
+```
+
+## Code
+```css
+/*! minions.css */
+.fd-c{flex-direction:column}
+.fd-r{flex-direction:row}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/flex-direction
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/flex-direction/index.html
+++ b/packages/flex-direction/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.flex-direction | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.flex-direction</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/flex-direction">
     source on Github
   </a>
 
@@ -23,12 +23,9 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.fd-c{flex-direction:column}
+.fd-r{flex-direction:row}
 
     </code>
   </pre>
@@ -37,10 +34,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.flex-direction@0.0.4-alpha-3</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.flex-direction@0.0.4-alpha-3" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/flex-flow/README.md
+++ b/packages/flex-flow/README.md
@@ -1,0 +1,41 @@
+# minions.flex-flow
+minions flex-flow classes
+
+## Module
+name: `minions.minions.flex-flow`  
+version: `0.0.4-alpha-8`  
+main/style: `flex-flow.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.flex-flow@0.0.4-alpha-8
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.flex-flow@0.0.4-alpha-8" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ff-r{flex-flow:row}
+.ff-rr{flex-flow:row-reverse}
+.ff-c{flex-flow:column}
+.ff-cr{flex-flow:column-reverse}
+.ff-n{flex-flow:nowrap}
+.ff-w{flex-flow:wrap}
+.ff-wr{flex-flow:wrap-reverse}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-8/packages/flex-flow
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/flex-flow/index.html
+++ b/packages/flex-flow/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.flex-flow | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.flex-flow</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-8/packages/flex-flow">
     source on Github
   </a>
 
@@ -23,12 +23,14 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ff-r{flex-flow:row}
+.ff-rr{flex-flow:row-reverse}
+.ff-c{flex-flow:column}
+.ff-cr{flex-flow:column-reverse}
+.ff-n{flex-flow:nowrap}
+.ff-w{flex-flow:wrap}
+.ff-wr{flex-flow:wrap-reverse}
 
     </code>
   </pre>
@@ -37,10 +39,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.flex-flow@0.0.4-alpha-8</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.flex-flow@0.0.4-alpha-8" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/flex-grow/README.md
+++ b/packages/flex-grow/README.md
@@ -1,0 +1,40 @@
+# minions.flex-grow
+minions flex-grow classes
+
+## Module
+name: `minions.minions.flex-grow`  
+version: `0.0.4-alpha-8`  
+main/style: `flex-grow.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.flex-grow@0.0.4-alpha-8
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.flex-grow@0.0.4-alpha-8" />
+```
+
+## Code
+```css
+/*! minions.css */
+.fg-1{flex-grow:1}
+.fg-2{flex-grow:2}
+.fg-3{flex-grow:3}
+.fg-4{flex-grow:4}
+.fg-5{flex-grow:5}
+.fg-6{flex-grow:6}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-8/packages/flex-grow
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/flex-grow/index.html
+++ b/packages/flex-grow/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.flex-grow | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.flex-grow</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-8/packages/flex-grow">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.fg-1{flex-grow:1}
+.fg-2{flex-grow:2}
+.fg-3{flex-grow:3}
+.fg-4{flex-grow:4}
+.fg-5{flex-grow:5}
+.fg-6{flex-grow:6}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.flex-grow@0.0.4-alpha-8</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.flex-grow@0.0.4-alpha-8" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/flex-shrink/README.md
+++ b/packages/flex-shrink/README.md
@@ -1,0 +1,40 @@
+# minions.flex-shrink
+minions flex-shrink classes
+
+## Module
+name: `minions.minions.flex-shrink`  
+version: `0.0.4-alpha-8`  
+main/style: `flex-shrink.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.flex-shrink@0.0.4-alpha-8
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.flex-shrink@0.0.4-alpha-8" />
+```
+
+## Code
+```css
+/*! minions.css */
+.fs-1{flex-shrink:1}
+.fs-2{flex-shrink:2}
+.fs-3{flex-shrink:3}
+.fs-4{flex-shrink:4}
+.fs-5{flex-shrink:5}
+.fs-6{flex-shrink:6}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-8/packages/flex-shrink
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/flex-shrink/index.html
+++ b/packages/flex-shrink/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.flex-shrink | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.flex-shrink</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-8/packages/flex-shrink">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.fs-1{flex-shrink:1}
+.fs-2{flex-shrink:2}
+.fs-3{flex-shrink:3}
+.fs-4{flex-shrink:4}
+.fs-5{flex-shrink:5}
+.fs-6{flex-shrink:6}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.flex-shrink@0.0.4-alpha-8</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.flex-shrink@0.0.4-alpha-8" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/flex-wrap/README.md
+++ b/packages/flex-wrap/README.md
@@ -1,0 +1,37 @@
+# minions.flex-wrap
+minions flex-wrap classes
+
+## Module
+name: `minions.minions.flex-wrap`  
+version: `0.0.4-alpha-3`  
+main/style: `flex-wrap.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.flex-wrap@0.0.4-alpha-3
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.flex-wrap@0.0.4-alpha-3" />
+```
+
+## Code
+```css
+/*! minions.css */
+.fw-n{flex-wrap:nowrap}
+.fw-w{flex-wrap:wrap}
+.fw-wr{flex-wrap:wrap-reverse}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/flex-wrap
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/flex-wrap/index.html
+++ b/packages/flex-wrap/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.flex-wrap | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.flex-wrap</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/flex-wrap">
     source on Github
   </a>
 
@@ -23,12 +23,10 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.fw-n{flex-wrap:nowrap}
+.fw-w{flex-wrap:wrap}
+.fw-wr{flex-wrap:wrap-reverse}
 
     </code>
   </pre>
@@ -37,10 +35,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.flex-wrap@0.0.4-alpha-3</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.flex-wrap@0.0.4-alpha-3" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/flex/README.md
+++ b/packages/flex/README.md
@@ -1,0 +1,40 @@
+# minions.flex
+minions flex classes
+
+## Module
+name: `minions.minions.flex`  
+version: `0.0.4-alpha-3`  
+main/style: `flex.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.flex@0.0.4-alpha-3
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.flex@0.0.4-alpha-3" />
+```
+
+## Code
+```css
+/*! minions.css */
+.f-1{flex:1}
+.f-2{flex:2}
+.f-3{flex:3}
+.f-4{flex:4}
+.f-5{flex:5}
+.f-6{flex:6}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/flex
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/flex/index.html
+++ b/packages/flex/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.flex | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.flex</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/flex">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.f-1{flex:1}
+.f-2{flex:2}
+.f-3{flex:3}
+.f-4{flex:4}
+.f-5{flex:5}
+.f-6{flex:6}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.flex@0.0.4-alpha-3</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.flex@0.0.4-alpha-3" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/float/README.md
+++ b/packages/float/README.md
@@ -1,0 +1,37 @@
+# minions.float
+minions float classes
+
+## Module
+name: `minions.minions.float`  
+version: `0.0.4-alpha-4`  
+main/style: `float.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.float@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.float@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.f-l{float:left}
+.f-n{float:none}
+.f-r{float:right}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/float
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/float/index.html
+++ b/packages/float/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.float | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.float</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/float">
     source on Github
   </a>
 
@@ -23,12 +23,10 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.f-l{float:left}
+.f-n{float:none}
+.f-r{float:right}
 
     </code>
   </pre>
@@ -37,10 +35,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.float@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.float@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/font-family/README.md
+++ b/packages/font-family/README.md
@@ -1,0 +1,41 @@
+# minions.font-family
+minions font-family classes
+
+## Module
+name: `minions.minions.font-family`  
+version: `0.0.4-alpha-3`  
+main/style: `font-family.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.font-family@0.0.4-alpha-3
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.font-family@0.0.4-alpha-3" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ff-s{font-family:serif}
+.ff-ss{font-family:sans-serif}
+.ff-m{font-family:monospace}
+.ff-c{font-family:cursive}
+.ff-f{font-family:fantasy}
+.ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
+.ff-system-serif{font-family:athelas, serif}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/font-family
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/font-family/index.html
+++ b/packages/font-family/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.font-family | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.font-family</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/font-family">
     source on Github
   </a>
 
@@ -23,12 +23,14 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ff-s{font-family:serif}
+.ff-ss{font-family:sans-serif}
+.ff-m{font-family:monospace}
+.ff-c{font-family:cursive}
+.ff-f{font-family:fantasy}
+.ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
+.ff-system-serif{font-family:athelas, serif}
 
     </code>
   </pre>
@@ -37,10 +39,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.font-family@0.0.4-alpha-3</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.font-family@0.0.4-alpha-3" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/font-style/README.md
+++ b/packages/font-style/README.md
@@ -1,0 +1,37 @@
+# minions.font-style
+minions font-style classes
+
+## Module
+name: `minions.minions.font-style`  
+version: `0.0.4-alpha-3`  
+main/style: `font-style.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.font-style@0.0.4-alpha-3
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.font-style@0.0.4-alpha-3" />
+```
+
+## Code
+```css
+/*! minions.css */
+.fs-n{font-style:normal}
+.fs-i{font-style:italic}
+.fs-o{font-style:oblique}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/font-style
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/font-style/index.html
+++ b/packages/font-style/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.font-style | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.font-style</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/font-style">
     source on Github
   </a>
 
@@ -23,12 +23,10 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.fs-n{font-style:normal}
+.fs-i{font-style:italic}
+.fs-o{font-style:oblique}
 
     </code>
   </pre>
@@ -37,10 +35,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.font-style@0.0.4-alpha-3</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.font-style@0.0.4-alpha-3" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/font-variant/README.md
+++ b/packages/font-variant/README.md
@@ -1,0 +1,35 @@
+# minions.font-variant
+minions font-variant classes
+
+## Module
+name: `minions.minions.font-variant`  
+version: `0.0.4-alpha-8`  
+main/style: `font-variant.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.font-variant@0.0.4-alpha-8
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.font-variant@0.0.4-alpha-8" />
+```
+
+## Code
+```css
+/*! minions.css */
+.fv-sc{font-variant: small-caps}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-8/packages/font-variant
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/font-variant/index.html
+++ b/packages/font-variant/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.font-variant | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.font-variant</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-8/packages/font-variant">
     source on Github
   </a>
 
@@ -23,12 +23,8 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.fv-sc{font-variant: small-caps}
 
     </code>
   </pre>
@@ -37,10 +33,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.font-variant@0.0.4-alpha-8</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.font-variant@0.0.4-alpha-8" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/font-weight/README.md
+++ b/packages/font-weight/README.md
@@ -1,0 +1,47 @@
+# minions.font-weight
+minions font-weight classes
+
+## Module
+name: `minions.minions.font-weight`  
+version: `0.0.4-alpha-3`  
+main/style: `font-weight.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.font-weight@0.0.4-alpha-3
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.font-weight@0.0.4-alpha-3" />
+```
+
+## Code
+```css
+/*! minions.css */
+.fw-n{font-weight:normal}
+.fw-b{font-weight:bold}
+.fw-l{font-weight:lighter}
+.fw-r{font-weight:bolder}
+.fw-100{font-weight:100}
+.fw-200{font-weight:200}
+.fw-300{font-weight:300}
+.fw-400{font-weight:400}
+.fw-500{font-weight:500}
+.fw-600{font-weight:600}
+.fw-700{font-weight:700}
+.fw-800{font-weight:800}
+.fw-900{font-weight:900}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/font-weight
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/font-weight/index.html
+++ b/packages/font-weight/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.font-weight | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.font-weight</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-3/packages/font-weight">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.fw-n{font-weight:normal}
+.fw-b{font-weight:bold}
+.fw-l{font-weight:lighter}
+.fw-r{font-weight:bolder}
+.fw-100{font-weight:100}
+.fw-200{font-weight:200}
+.fw-300{font-weight:300}
+.fw-400{font-weight:400}
+.fw-500{font-weight:500}
+.fw-600{font-weight:600}
+.fw-700{font-weight:700}
+.fw-800{font-weight:800}
+.fw-900{font-weight:900}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.font-weight@0.0.4-alpha-3</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.font-weight@0.0.4-alpha-3" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/height/README.md
+++ b/packages/height/README.md
@@ -1,0 +1,52 @@
+# minions.height
+minions height classes
+
+## Module
+name: `minions.minions.height`  
+version: `0.0.4-alpha-9`  
+main/style: `height.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.height@0.0.4-alpha-9
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.height@0.0.4-alpha-9" />
+```
+
+## Code
+```css
+/*! minions.css */
+.h-a{height:auto}
+.h-mc{height:max-content}
+.h-nc{height:min-content}
+.h-fc{height:fit-content}
+.h-10\%{height:10%}
+.h-20\%{height:20%}
+.h-25\%{height:25%}
+.h-30\%{height:30%}
+.h-33\%{height:33.3333%}
+.h-40\%{height:40%}
+.h-50\%{height:50%}
+.h-60\%{height:60%}
+.h-66\%{height:66.6666%}
+.h-70\%{height:70%}
+.h-75\%{height:75%}
+.h-80\%{height:80%}
+.h-90\%{height:90%}
+.h-100\%{height:100%}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/height
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/height/index.html
+++ b/packages/height/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.height | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.height</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/height">
     source on Github
   </a>
 
@@ -23,12 +23,25 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.h-a{height:auto}
+.h-mc{height:max-content}
+.h-nc{height:min-content}
+.h-fc{height:fit-content}
+.h-10\%{height:10%}
+.h-20\%{height:20%}
+.h-25\%{height:25%}
+.h-30\%{height:30%}
+.h-33\%{height:33.3333%}
+.h-40\%{height:40%}
+.h-50\%{height:50%}
+.h-60\%{height:60%}
+.h-66\%{height:66.6666%}
+.h-70\%{height:70%}
+.h-75\%{height:75%}
+.h-80\%{height:80%}
+.h-90\%{height:90%}
+.h-100\%{height:100%}
 
     </code>
   </pre>
@@ -37,10 +50,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.height@0.0.4-alpha-9</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.height@0.0.4-alpha-9" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/justify-content/README.md
+++ b/packages/justify-content/README.md
@@ -1,0 +1,39 @@
+# minions.justify-content
+minions justify-content classes
+
+## Module
+name: `minions.minions.justify-content`  
+version: `0.0.4-alpha-14`  
+main/style: `justify-content.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.justify-content@0.0.4-alpha-14
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.justify-content@0.0.4-alpha-14" />
+```
+
+## Code
+```css
+/*! minions.css */
+.jc-c{justify-content:center}
+.jc-fe{justify-content:flex-end}
+.jc-fs{justify-content:flex-start}
+.jc-sb{justify-content:space-between}
+.jc-sa{justify-content:space-around}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/justify-content
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/justify-content/index.html
+++ b/packages/justify-content/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.justify-content | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.justify-content</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/justify-content">
     source on Github
   </a>
 
@@ -23,12 +23,12 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.jc-c{justify-content:center}
+.jc-fe{justify-content:flex-end}
+.jc-fs{justify-content:flex-start}
+.jc-sb{justify-content:space-between}
+.jc-sa{justify-content:space-around}
 
     </code>
   </pre>
@@ -37,10 +37,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.justify-content@0.0.4-alpha-14</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.justify-content@0.0.4-alpha-14" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/left/README.md
+++ b/packages/left/README.md
@@ -1,0 +1,51 @@
+# minions.left
+minions left classes
+
+## Module
+name: `minions.minions.left`  
+version: `0.0.4-alpha-5`  
+main/style: `left.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.left@0.0.4-alpha-5
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.left@0.0.4-alpha-5" />
+```
+
+## Code
+```css
+/*! minions.css */
+.l-0{left:0}
+.l-1p{left:1px}
+.l-2p{left:1px}
+.l-3p{left:3px}
+.l-4p{left:4px}
+.l-\.25{left:.25em}
+.l-\.5{left:.5em}
+.l-1{left:1em}
+.l-2{left:2em}
+.l-3{left:3em}
+.l-4{left:4em}
+.l-\.25r{left:.25em}
+.l-\.5r{left:.5em}
+.l-1r{left:1em}
+.l-2r{left:2em}
+.l-3r{left:3em}
+.l-4r{left:4em}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-5/packages/left
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/left/index.html
+++ b/packages/left/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.left | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.left</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-5/packages/left">
     source on Github
   </a>
 
@@ -23,12 +23,24 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.l-0{left:0}
+.l-1p{left:1px}
+.l-2p{left:1px}
+.l-3p{left:3px}
+.l-4p{left:4px}
+.l-\.25{left:.25em}
+.l-\.5{left:.5em}
+.l-1{left:1em}
+.l-2{left:2em}
+.l-3{left:3em}
+.l-4{left:4em}
+.l-\.25r{left:.25em}
+.l-\.5r{left:.5em}
+.l-1r{left:1em}
+.l-2r{left:2em}
+.l-3r{left:3em}
+.l-4r{left:4em}
 
     </code>
   </pre>
@@ -37,10 +49,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.left@0.0.4-alpha-5</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.left@0.0.4-alpha-5" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/letter-spacing/README.md
+++ b/packages/letter-spacing/README.md
@@ -1,0 +1,38 @@
+# minions.letter-spacing
+minions letter-spacing classes
+
+## Module
+name: `minions.minions.letter-spacing`  
+version: `0.0.4-alpha-9`  
+main/style: `letter-spacing.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.letter-spacing@0.0.4-alpha-9
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.letter-spacing@0.0.4-alpha-9" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ls-tracked{letter-spacing:.1}
+.ls-tight{letter-spacing:-.05em}
+.ls-wide{letter-spacing:.25em}
+.ls-normal{letter-spacing:normal}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/letter-spacing
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/letter-spacing/index.html
+++ b/packages/letter-spacing/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.letter-spacing | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.letter-spacing</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/letter-spacing">
     source on Github
   </a>
 
@@ -23,12 +23,11 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ls-tracked{letter-spacing:.1}
+.ls-tight{letter-spacing:-.05em}
+.ls-wide{letter-spacing:.25em}
+.ls-normal{letter-spacing:normal}
 
     </code>
   </pre>
@@ -37,10 +36,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.letter-spacing@0.0.4-alpha-9</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.letter-spacing@0.0.4-alpha-9" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/line-height/README.md
+++ b/packages/line-height/README.md
@@ -1,0 +1,39 @@
+# minions.line-height
+minions line-height classes
+
+## Module
+name: `minions.minions.line-height`  
+version: `0.0.4-alpha-9`  
+main/style: `line-height.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.line-height@0.0.4-alpha-9
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.line-height@0.0.4-alpha-9" />
+```
+
+## Code
+```css
+/*! minions.css */
+.lh-1{line-height:1}
+.lh-1\.25{line-height:1.25}
+.lh-1\.5{line-height:1.5}
+.lh-2{line-height:2}
+.lh-n{line-height:normal}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/line-height
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/line-height/index.html
+++ b/packages/line-height/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.line-height | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.line-height</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/line-height">
     source on Github
   </a>
 
@@ -23,12 +23,12 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.lh-1{line-height:1}
+.lh-1\.25{line-height:1.25}
+.lh-1\.5{line-height:1.5}
+.lh-2{line-height:2}
+.lh-n{line-height:normal}
 
     </code>
   </pre>
@@ -37,10 +37,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.line-height@0.0.4-alpha-9</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.line-height@0.0.4-alpha-9" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/list-style-position/README.md
+++ b/packages/list-style-position/README.md
@@ -1,0 +1,36 @@
+# minions.list-style-position
+minions list-style-position classes
+
+## Module
+name: `minions.minions.list-style-position`  
+version: `0.0.4-alpha-9`  
+main/style: `list-style-position.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.list-style-position@0.0.4-alpha-9
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.list-style-position@0.0.4-alpha-9" />
+```
+
+## Code
+```css
+/*! minions.css */
+.lsp-i{list-style-position:inside}
+.lsp-o{list-style-position:outside}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/list-style-position
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/list-style-position/index.html
+++ b/packages/list-style-position/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.list-style-position | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.list-style-position</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/list-style-position">
     source on Github
   </a>
 
@@ -23,12 +23,9 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.lsp-i{list-style-position:inside}
+.lsp-o{list-style-position:outside}
 
     </code>
   </pre>
@@ -37,10 +34,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.list-style-position@0.0.4-alpha-9</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.list-style-position@0.0.4-alpha-9" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/list-style-type/README.md
+++ b/packages/list-style-type/README.md
@@ -1,0 +1,42 @@
+# minions.list-style-type
+minions list-style-type classes
+
+## Module
+name: `minions.minions.list-style-type`  
+version: `0.0.4-alpha-5`  
+main/style: `list-style-type.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.list-style-type@0.0.4-alpha-5
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.list-style-type@0.0.4-alpha-5" />
+```
+
+## Code
+```css
+/*! minions.css */
+.lst-d{list-style-type:disc}
+.lst-c{list-style-type:circle}
+.lst-s{list-style-type:square}
+.lst-l{list-style-type:decimal}
+.lst-g{list-style-type:georgian}
+.lst-ci{list-style-type:cjk-ideographic}
+.lst-k{list-style-type:kannada}
+.lst-n{list-style-type:none}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-5/packages/list-style-type
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/list-style-type/index.html
+++ b/packages/list-style-type/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.list-style-type | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.list-style-type</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-5/packages/list-style-type">
     source on Github
   </a>
 
@@ -23,12 +23,15 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.lst-d{list-style-type:disc}
+.lst-c{list-style-type:circle}
+.lst-s{list-style-type:square}
+.lst-l{list-style-type:decimal}
+.lst-g{list-style-type:georgian}
+.lst-ci{list-style-type:cjk-ideographic}
+.lst-k{list-style-type:kannada}
+.lst-n{list-style-type:none}
 
     </code>
   </pre>
@@ -37,10 +40,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.list-style-type@0.0.4-alpha-5</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.list-style-type@0.0.4-alpha-5" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/margin-bottom/README.md
+++ b/packages/margin-bottom/README.md
@@ -1,0 +1,47 @@
+# minions.margin-bottom
+minions margin-bottom classes
+
+## Module
+name: `minions.minions.margin-bottom`  
+version: `0.0.4-alpah-13`  
+main/style: `margin-bottom.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.margin-bottom@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.margin-bottom@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.mb-0{margin-bottom:0}
+.mb-\.25e{margin-bottom:.25em}
+.mb-\.5e{margin-bottom:.5em}
+.mb-1e{margin-bottom:1em}
+.mb-2e{margin-bottom:2em}
+.mb-3e{margin-bottom:3em}
+.mb-4e{margin-bottom:4em}
+.mb-\.25r{margin-bottom:.25rem}
+.mb-\.5r{margin-bottom:.5rem}
+.mb-1r{margin-bottom:1rem}
+.mb-2r{margin-bottom:2rem}
+.mb-3r{margin-bottom:3rem}
+.mb-4r{margin-bottom:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin-bottom
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/margin-bottom/index.html
+++ b/packages/margin-bottom/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.margin-bottom | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.margin-bottom</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin-bottom">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.mb-0{margin-bottom:0}
+.mb-\.25e{margin-bottom:.25em}
+.mb-\.5e{margin-bottom:.5em}
+.mb-1e{margin-bottom:1em}
+.mb-2e{margin-bottom:2em}
+.mb-3e{margin-bottom:3em}
+.mb-4e{margin-bottom:4em}
+.mb-\.25r{margin-bottom:.25rem}
+.mb-\.5r{margin-bottom:.5rem}
+.mb-1r{margin-bottom:1rem}
+.mb-2r{margin-bottom:2rem}
+.mb-3r{margin-bottom:3rem}
+.mb-4r{margin-bottom:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.margin-bottom@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.margin-bottom@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/margin-left/README.md
+++ b/packages/margin-left/README.md
@@ -1,0 +1,47 @@
+# minions.margin-left
+minions margin-left classes
+
+## Module
+name: `minions.minions.margin-left`  
+version: `0.0.4-alpah-13`  
+main/style: `margin-left.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.margin-left@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.margin-left@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ml-0{margin-left:0}
+.ml-\.25e{margin-left:.25em}
+.ml-\.5e{margin-left:.5em}
+.ml-1e{margin-left:1em}
+.ml-2e{margin-left:2em}
+.ml-3e{margin-left:3em}
+.ml-4e{margin-left:4em}
+.ml-\.25r{margin-left:.25rem}
+.ml-\.5r{margin-left:.5rem}
+.ml-1r{margin-left:1rem}
+.ml-2r{margin-left:2rem}
+.ml-3r{margin-left:3rem}
+.ml-4r{margin-left:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin-left
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/margin-left/index.html
+++ b/packages/margin-left/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.margin-left | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.margin-left</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin-left">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ml-0{margin-left:0}
+.ml-\.25e{margin-left:.25em}
+.ml-\.5e{margin-left:.5em}
+.ml-1e{margin-left:1em}
+.ml-2e{margin-left:2em}
+.ml-3e{margin-left:3em}
+.ml-4e{margin-left:4em}
+.ml-\.25r{margin-left:.25rem}
+.ml-\.5r{margin-left:.5rem}
+.ml-1r{margin-left:1rem}
+.ml-2r{margin-left:2rem}
+.ml-3r{margin-left:3rem}
+.ml-4r{margin-left:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.margin-left@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.margin-left@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/margin-right/README.md
+++ b/packages/margin-right/README.md
@@ -1,0 +1,47 @@
+# minions.margin-right
+minions margin-right classes
+
+## Module
+name: `minions.minions.margin-right`  
+version: `0.0.4-alpah-13`  
+main/style: `margin-right.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.margin-right@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.margin-right@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.mr-0{margin-right:0}
+.mr-\.25e{margin-right:.25em}
+.mr-\.5e{margin-right:.5em}
+.mr-1e{margin-right:1em}
+.mr-2e{margin-right:2em}
+.mr-3e{margin-right:3em}
+.mr-4e{margin-right:4em}
+.mr-\.25r{margin-right:.25rem}
+.mr-\.5r{margin-right:.5rem}
+.mr-1r{margin-right:1rem}
+.mr-2r{margin-right:2rem}
+.mr-3r{margin-right:3rem}
+.mr-4r{margin-right:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin-right
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/margin-right/index.html
+++ b/packages/margin-right/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.margin-right | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.margin-right</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin-right">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.mr-0{margin-right:0}
+.mr-\.25e{margin-right:.25em}
+.mr-\.5e{margin-right:.5em}
+.mr-1e{margin-right:1em}
+.mr-2e{margin-right:2em}
+.mr-3e{margin-right:3em}
+.mr-4e{margin-right:4em}
+.mr-\.25r{margin-right:.25rem}
+.mr-\.5r{margin-right:.5rem}
+.mr-1r{margin-right:1rem}
+.mr-2r{margin-right:2rem}
+.mr-3r{margin-right:3rem}
+.mr-4r{margin-right:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.margin-right@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.margin-right@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/margin-top/README.md
+++ b/packages/margin-top/README.md
@@ -1,0 +1,47 @@
+# minions.margin-top
+minions margin-top classes
+
+## Module
+name: `minions.minions.margin-top`  
+version: `0.0.4-alpah-13`  
+main/style: `margin-top.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.margin-top@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.margin-top@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.mt-0{margin-top:0}
+.mt-\.25e{margin-top:.25em}
+.mt-\.5e{margin-top:.5em}
+.mt-1e{margin-top:1em}
+.mt-2e{margin-top:2em}
+.mt-3e{margin-top:3em}
+.mt-4e{margin-top:4em}
+.mt-\.25r{margin-top:.25rem}
+.mt-\.5r{margin-top:.5rem}
+.mt-1r{margin-top:1rem}
+.mt-2r{margin-top:2rem}
+.mt-3r{margin-top:3rem}
+.mt-4r{margin-top:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin-top
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/margin-top/index.html
+++ b/packages/margin-top/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.margin-top | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.margin-top</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin-top">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.mt-0{margin-top:0}
+.mt-\.25e{margin-top:.25em}
+.mt-\.5e{margin-top:.5em}
+.mt-1e{margin-top:1em}
+.mt-2e{margin-top:2em}
+.mt-3e{margin-top:3em}
+.mt-4e{margin-top:4em}
+.mt-\.25r{margin-top:.25rem}
+.mt-\.5r{margin-top:.5rem}
+.mt-1r{margin-top:1rem}
+.mt-2r{margin-top:2rem}
+.mt-3r{margin-top:3rem}
+.mt-4r{margin-top:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.margin-top@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.margin-top@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/margin-x/README.md
+++ b/packages/margin-x/README.md
@@ -1,0 +1,47 @@
+# minions.margin-x
+minions margin-x classes
+
+## Module
+name: `minions.minions.margin-x`  
+version: `0.0.4-alpah-13`  
+main/style: `margin-x.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.margin-x@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.margin-x@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.mx-0{margin-right:0;margin-left:0}
+.mx-\.25e{margin-right:.25em;margin-left:.25em}
+.mx-\.5e{margin-right:.5em;margin-left:.5em}
+.mx-1e{margin-right:1em;margin-left:1em}
+.mx-2e{margin-right:2em;margin-left:2em}
+.mx-3e{margin-right:3em;margin-left:3em}
+.mx-4e{margin-right:4em;margin-left:4em}
+.mx-\.25r{margin-right:.25rem;margin-left:.25rem}
+.mx-\.5r{margin-right:.5rem;margin-left:.5rem}
+.mx-1r{margin-right:1rem;margin-left:1rem}
+.mx-2r{margin-right:2rem;margin-left:2rem}
+.mx-3r{margin-right:3rem;margin-left:3rem}
+.mx-4r{margin-right:4rem;margin-left:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin-x
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/margin-x/index.html
+++ b/packages/margin-x/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.margin-x | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.margin-x</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin-x">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.mx-0{margin-right:0;margin-left:0}
+.mx-\.25e{margin-right:.25em;margin-left:.25em}
+.mx-\.5e{margin-right:.5em;margin-left:.5em}
+.mx-1e{margin-right:1em;margin-left:1em}
+.mx-2e{margin-right:2em;margin-left:2em}
+.mx-3e{margin-right:3em;margin-left:3em}
+.mx-4e{margin-right:4em;margin-left:4em}
+.mx-\.25r{margin-right:.25rem;margin-left:.25rem}
+.mx-\.5r{margin-right:.5rem;margin-left:.5rem}
+.mx-1r{margin-right:1rem;margin-left:1rem}
+.mx-2r{margin-right:2rem;margin-left:2rem}
+.mx-3r{margin-right:3rem;margin-left:3rem}
+.mx-4r{margin-right:4rem;margin-left:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.margin-x@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.margin-x@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/margin-y/README.md
+++ b/packages/margin-y/README.md
@@ -1,0 +1,47 @@
+# minions.margin-y
+minions margin-y classes
+
+## Module
+name: `minions.minions.margin-y`  
+version: `0.0.4-alpah-13`  
+main/style: `margin-y.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.margin-y@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.margin-y@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.my-0{margin-top:0;margin-bottom:0}
+.my-\.25e{margin-top:.25em;margin-bottom:.25em}
+.my-\.5e{margin-top:.5em;margin-bottom:.5em}
+.my-1e{margin-top:1em;margin-bottom:1em}
+.my-2e{margin-top:2em;margin-bottom:2em}
+.my-3e{margin-top:3em;margin-bottom:3em}
+.my-4e{margin-top:4em;margin-bottom:4em}
+.my-\.25r{margin-top:.25rem;margin-bottom:.25rem}
+.my-\.5r{margin-top:.5rem;margin-bottom:.5rem}
+.my-1r{margin-top:1rem;margin-bottom:1rem}
+.my-2r{margin-top:2rem;margin-bottom:2rem}
+.my-3r{margin-top:3rem;margin-bottom:3rem}
+.my-4r{margin-top:4rem;margin-bottom:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin-y
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/margin-y/index.html
+++ b/packages/margin-y/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.margin-y | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.margin-y</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin-y">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.my-0{margin-top:0;margin-bottom:0}
+.my-\.25e{margin-top:.25em;margin-bottom:.25em}
+.my-\.5e{margin-top:.5em;margin-bottom:.5em}
+.my-1e{margin-top:1em;margin-bottom:1em}
+.my-2e{margin-top:2em;margin-bottom:2em}
+.my-3e{margin-top:3em;margin-bottom:3em}
+.my-4e{margin-top:4em;margin-bottom:4em}
+.my-\.25r{margin-top:.25rem;margin-bottom:.25rem}
+.my-\.5r{margin-top:.5rem;margin-bottom:.5rem}
+.my-1r{margin-top:1rem;margin-bottom:1rem}
+.my-2r{margin-top:2rem;margin-bottom:2rem}
+.my-3r{margin-top:3rem;margin-bottom:3rem}
+.my-4r{margin-top:4rem;margin-bottom:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.margin-y@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.margin-y@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/margin/README.md
+++ b/packages/margin/README.md
@@ -1,0 +1,48 @@
+# minions.margin
+minions margin classes
+
+## Module
+name: `minions.minions.margin`  
+version: `0.0.4-alpah-13`  
+main/style: `margin.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.margin@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.margin@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.m-0a{margin:0 auto}
+.m-0{margin:0}
+.m-\.25e{margin:.25em}
+.m-\.5e{margin:.5em}
+.m-1e{margin:1em}
+.m-2e{margin:2em}
+.m-3e{margin:3em}
+.m-4e{margin:4em}
+.m-\.25r{margin:.25rem}
+.m-\.5r{margin:.5rem}
+.m-1r{margin:1rem}
+.m-2r{margin:2rem}
+.m-3r{margin:3rem}
+.m-4r{margin:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/margin/index.html
+++ b/packages/margin/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.margin | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.margin</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/margin">
     source on Github
   </a>
 
@@ -23,12 +23,21 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.m-0a{margin:0 auto}
+.m-0{margin:0}
+.m-\.25e{margin:.25em}
+.m-\.5e{margin:.5em}
+.m-1e{margin:1em}
+.m-2e{margin:2em}
+.m-3e{margin:3em}
+.m-4e{margin:4em}
+.m-\.25r{margin:.25rem}
+.m-\.5r{margin:.5rem}
+.m-1r{margin:1rem}
+.m-2r{margin:2rem}
+.m-3r{margin:3rem}
+.m-4r{margin:4rem}
 
     </code>
   </pre>
@@ -37,10 +46,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.margin@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.margin@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/max-height/README.md
+++ b/packages/max-height/README.md
@@ -1,0 +1,53 @@
+# minions.max-height
+minions max-height classes
+
+## Module
+name: `minions.minions.max-height`  
+version: `0.0.4-alpha-9`  
+main/style: `max-height.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.max-height@0.0.4-alpha-9
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.max-height@0.0.4-alpha-9" />
+```
+
+## Code
+```css
+/*! minions.css */
+.xh-a{max-height:auto}
+.xh-xc{max-height:max-content}
+.xh-nc{max-height:min-content}
+.xh-fc{max-height:fit-content}
+.xh-fa{max-height:fill-available}
+.xh-10\%{max-height:10%}
+.xh-20\%{max-height:20%}
+.xh-25\%{max-height:25%}
+.xh-30\%{max-height:30%}
+.xh-33\%{max-height:33.3333%}
+.xh-40\%{max-height:40%}
+.xh-50\%{max-height:50%}
+.xh-60\%{max-height:60%}
+.xh-66\%{max-height:66.6666%}
+.xh-70\%{max-height:70%}
+.xh-75\%{max-height:75%}
+.xh-80\%{max-height:80%}
+.xh-90\%{max-height:90%}
+.xh-100\%{max-height:100%}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/max-height
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/max-height/index.html
+++ b/packages/max-height/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.max-height | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.max-height</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/max-height">
     source on Github
   </a>
 
@@ -23,12 +23,26 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.xh-a{max-height:auto}
+.xh-xc{max-height:max-content}
+.xh-nc{max-height:min-content}
+.xh-fc{max-height:fit-content}
+.xh-fa{max-height:fill-available}
+.xh-10\%{max-height:10%}
+.xh-20\%{max-height:20%}
+.xh-25\%{max-height:25%}
+.xh-30\%{max-height:30%}
+.xh-33\%{max-height:33.3333%}
+.xh-40\%{max-height:40%}
+.xh-50\%{max-height:50%}
+.xh-60\%{max-height:60%}
+.xh-66\%{max-height:66.6666%}
+.xh-70\%{max-height:70%}
+.xh-75\%{max-height:75%}
+.xh-80\%{max-height:80%}
+.xh-90\%{max-height:90%}
+.xh-100\%{max-height:100%}
 
     </code>
   </pre>
@@ -37,10 +51,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.max-height@0.0.4-alpha-9</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.max-height@0.0.4-alpha-9" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/max-width/README.md
+++ b/packages/max-width/README.md
@@ -1,0 +1,53 @@
+# minions.max-width
+minions max-width classes
+
+## Module
+name: `minions.minions.max-width`  
+version: `0.0.4-alpha-9`  
+main/style: `max-width.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.max-width@0.0.4-alpha-9
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.max-width@0.0.4-alpha-9" />
+```
+
+## Code
+```css
+/*! minions.css */
+.xw-a{max-width:auto}
+.xw-xc{max-width:max-content}
+.xw-nc{max-width:min-content}
+.xw-fc{max-width:fit-content}
+.xw-fa{max-width:fill-available}
+.xw-10\%{max-width:10%}
+.xw-20\%{max-width:20%}
+.xw-25\%{max-width:25%}
+.xw-30\%{max-width:30%}
+.xw-33\%{max-width:33.3333%}
+.xw-40\%{max-width:40%}
+.xw-50\%{max-width:50%}
+.xw-60\%{max-width:60%}
+.xw-66\%{max-width:66.6666%}
+.xw-70\%{max-width:70%}
+.xw-75\%{max-width:75%}
+.xw-80\%{max-width:80%}
+.xw-90\%{max-width:90%}
+.xw-100\%{max-width:100%}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/max-width
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/max-width/index.html
+++ b/packages/max-width/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.max-width | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.max-width</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/max-width">
     source on Github
   </a>
 
@@ -23,12 +23,26 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.xw-a{max-width:auto}
+.xw-xc{max-width:max-content}
+.xw-nc{max-width:min-content}
+.xw-fc{max-width:fit-content}
+.xw-fa{max-width:fill-available}
+.xw-10\%{max-width:10%}
+.xw-20\%{max-width:20%}
+.xw-25\%{max-width:25%}
+.xw-30\%{max-width:30%}
+.xw-33\%{max-width:33.3333%}
+.xw-40\%{max-width:40%}
+.xw-50\%{max-width:50%}
+.xw-60\%{max-width:60%}
+.xw-66\%{max-width:66.6666%}
+.xw-70\%{max-width:70%}
+.xw-75\%{max-width:75%}
+.xw-80\%{max-width:80%}
+.xw-90\%{max-width:90%}
+.xw-100\%{max-width:100%}
 
     </code>
   </pre>
@@ -37,10 +51,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.max-width@0.0.4-alpha-9</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.max-width@0.0.4-alpha-9" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/min-height/README.md
+++ b/packages/min-height/README.md
@@ -1,0 +1,53 @@
+# minions.min-height
+minions min-height classes
+
+## Module
+name: `minions.minions.min-height`  
+version: `0.0.4-alpha-9`  
+main/style: `min-height.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.min-height@0.0.4-alpha-9
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.min-height@0.0.4-alpha-9" />
+```
+
+## Code
+```css
+/*! minions.css */
+.nh-a{min-height:auto}
+.nh-xc{min-height:max-content}
+.nh-nc{min-height:min-content}
+.nh-fc{min-height:fit-content}
+.nh-fa{min-height:fill-available}
+.nh-10\%{min-height:10%}
+.nh-20\%{min-height:20%}
+.nh-25\%{min-height:25%}
+.nh-30\%{min-height:30%}
+.nh-33\%{min-height:33.3333%}
+.nh-40\%{min-height:40%}
+.nh-50\%{min-height:50%}
+.nh-60\%{min-height:60%}
+.nh-66\%{min-height:66.6666%}
+.nh-70\%{min-height:70%}
+.nh-75\%{min-height:75%}
+.nh-80\%{min-height:80%}
+.nh-90\%{min-height:90%}
+.nh-100\%{min-height:100%}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/min-height
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/min-height/index.html
+++ b/packages/min-height/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.min-height | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.min-height</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/min-height">
     source on Github
   </a>
 
@@ -23,12 +23,26 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.nh-a{min-height:auto}
+.nh-xc{min-height:max-content}
+.nh-nc{min-height:min-content}
+.nh-fc{min-height:fit-content}
+.nh-fa{min-height:fill-available}
+.nh-10\%{min-height:10%}
+.nh-20\%{min-height:20%}
+.nh-25\%{min-height:25%}
+.nh-30\%{min-height:30%}
+.nh-33\%{min-height:33.3333%}
+.nh-40\%{min-height:40%}
+.nh-50\%{min-height:50%}
+.nh-60\%{min-height:60%}
+.nh-66\%{min-height:66.6666%}
+.nh-70\%{min-height:70%}
+.nh-75\%{min-height:75%}
+.nh-80\%{min-height:80%}
+.nh-90\%{min-height:90%}
+.nh-100\%{min-height:100%}
 
     </code>
   </pre>
@@ -37,10 +51,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.min-height@0.0.4-alpha-9</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.min-height@0.0.4-alpha-9" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/min-width/README.md
+++ b/packages/min-width/README.md
@@ -1,0 +1,53 @@
+# minions.min-width
+minions min-width classes
+
+## Module
+name: `minions.minions.min-width`  
+version: `0.0.4-alpha-9`  
+main/style: `min-width.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.min-width@0.0.4-alpha-9
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.min-width@0.0.4-alpha-9" />
+```
+
+## Code
+```css
+/*! minions.css */
+.nw-a{min-width:auto}
+.nw-xc{min-width:max-content}
+.nw-nc{min-width:min-content}
+.nw-fc{min-width:fit-content}
+.nw-fa{min-width:fill-available}
+.nw-10\%{min-width:10%}
+.nw-20\%{min-width:20%}
+.nw-25\%{min-width:25%}
+.nw-30\%{min-width:30%}
+.nw-33\%{min-width:33.3333%}
+.nw-40\%{min-width:40%}
+.nw-50\%{min-width:50%}
+.nw-60\%{min-width:60%}
+.nw-66\%{min-width:66.6666%}
+.nw-70\%{min-width:70%}
+.nw-75\%{min-width:75%}
+.nw-80\%{min-width:80%}
+.nw-90\%{min-width:90%}
+.nw-100\%{min-width:100%}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/min-width
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/min-width/index.html
+++ b/packages/min-width/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.min-width | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.min-width</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/min-width">
     source on Github
   </a>
 
@@ -23,12 +23,26 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.nw-a{min-width:auto}
+.nw-xc{min-width:max-content}
+.nw-nc{min-width:min-content}
+.nw-fc{min-width:fit-content}
+.nw-fa{min-width:fill-available}
+.nw-10\%{min-width:10%}
+.nw-20\%{min-width:20%}
+.nw-25\%{min-width:25%}
+.nw-30\%{min-width:30%}
+.nw-33\%{min-width:33.3333%}
+.nw-40\%{min-width:40%}
+.nw-50\%{min-width:50%}
+.nw-60\%{min-width:60%}
+.nw-66\%{min-width:66.6666%}
+.nw-70\%{min-width:70%}
+.nw-75\%{min-width:75%}
+.nw-80\%{min-width:80%}
+.nw-90\%{min-width:90%}
+.nw-100\%{min-width:100%}
 
     </code>
   </pre>
@@ -37,10 +51,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.min-width@0.0.4-alpha-9</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.min-width@0.0.4-alpha-9" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/mix-blend-mode/README.md
+++ b/packages/mix-blend-mode/README.md
@@ -1,0 +1,51 @@
+# minions.mix-blend-mode
+minions mix-blend-mode classes
+
+## Module
+name: `minions.minions.mix-blend-mode`  
+version: `0.0.4-alpha-9`  
+main/style: `mix-blend-mode.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.mix-blend-mode@0.0.4-alpha-9
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.mix-blend-mode@0.0.4-alpha-9" />
+```
+
+## Code
+```css
+/* !minions.css */
+.mbm-c{mix-blend-mode:color}
+.mbm-cd{mix-blend-mode:color-dodge}
+.mbm-cb{mix-blend-mode:color-burn}
+.mbm-d{mix-blend-mode:darken}
+.mbm-e{mix-blend-mode:exclusion}
+.mbm-h{mix-blend-mode:hue}
+.mbm-hl{mix-blend-mode:hard-light}
+.mbm-l{mix-blend-mode:lighten}
+.mbm-m{mix-blend-mode:multiply}
+.mbm-n{mix-blend-mode:normal}
+.mbm-o{mix-blend-mode:overlay}
+.mbm-s{mix-blend-mode:screen}
+.mbm-sl{mix-blend-mode:soft-light}
+
+.mbm-diff{mix-blend-mode:difference}
+.mbm-sat{mix-blend-mode:saturation}
+.mbm-lum{mix-blend-mode:luminosity}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/mix-blend-mode
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/mix-blend-mode/index.html
+++ b/packages/mix-blend-mode/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.mix-blend-mode | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.mix-blend-mode</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-9/packages/mix-blend-mode">
     source on Github
   </a>
 
@@ -23,12 +23,24 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/* !minions.css */
+.mbm-c{mix-blend-mode:color}
+.mbm-cd{mix-blend-mode:color-dodge}
+.mbm-cb{mix-blend-mode:color-burn}
+.mbm-d{mix-blend-mode:darken}
+.mbm-e{mix-blend-mode:exclusion}
+.mbm-h{mix-blend-mode:hue}
+.mbm-hl{mix-blend-mode:hard-light}
+.mbm-l{mix-blend-mode:lighten}
+.mbm-m{mix-blend-mode:multiply}
+.mbm-n{mix-blend-mode:normal}
+.mbm-o{mix-blend-mode:overlay}
+.mbm-s{mix-blend-mode:screen}
+.mbm-sl{mix-blend-mode:soft-light}
+
+.mbm-diff{mix-blend-mode:difference}
+.mbm-sat{mix-blend-mode:saturation}
+.mbm-lum{mix-blend-mode:luminosity}
 
     </code>
   </pre>
@@ -37,10 +49,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.mix-blend-mode@0.0.4-alpha-9</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.mix-blend-mode@0.0.4-alpha-9" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/opacity/README.md
+++ b/packages/opacity/README.md
@@ -1,0 +1,45 @@
+# minions.opacity
+minions opacity classes
+
+## Module
+name: `minions.minions.opacity`  
+version: `0.0.4-alpha-4`  
+main/style: `opacity.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.opacity@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.opacity@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.o-1{opacity:1}
+.o-\.9{opacity:.9}
+.o-\.8{opacity:.8}
+.o-\.7{opacity:.7}
+.o-\.6{opacity:.6}
+.o-\.5{opacity:.5}
+.o-\.4{opacity:.4}
+.o-\.3{opacity:.3}
+.o-\.2{opacity:.2}
+.o-\.1{opacity:.1}
+.o-0{opacity:0}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/opacity
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/opacity/index.html
+++ b/packages/opacity/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.opacity | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.opacity</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/opacity">
     source on Github
   </a>
 
@@ -23,12 +23,18 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.o-1{opacity:1}
+.o-\.9{opacity:.9}
+.o-\.8{opacity:.8}
+.o-\.7{opacity:.7}
+.o-\.6{opacity:.6}
+.o-\.5{opacity:.5}
+.o-\.4{opacity:.4}
+.o-\.3{opacity:.3}
+.o-\.2{opacity:.2}
+.o-\.1{opacity:.1}
+.o-0{opacity:0}
 
     </code>
   </pre>
@@ -37,10 +43,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.opacity@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.opacity@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/outline-style/README.md
+++ b/packages/outline-style/README.md
@@ -1,0 +1,41 @@
+# minions.outline-style
+minions outline-style classes
+
+## Module
+name: `minions.minions.outline-style`  
+version: `0.0.4-alpha-10`  
+main/style: `outline-style.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.outline-style@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.outline-style@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.os-a{outline-style:auto}
+.os-d{outline-style:dotted}
+.os-n{outline-style:none}
+.os-s{outline-style:solid}
+.os-t{outline-style:thin}
+.os-m{outline-style:medium}
+.os-k{outline-style:thick}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/outline-style
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/outline-style/index.html
+++ b/packages/outline-style/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.outline-style | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.outline-style</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/outline-style">
     source on Github
   </a>
 
@@ -23,12 +23,14 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.os-a{outline-style:auto}
+.os-d{outline-style:dotted}
+.os-n{outline-style:none}
+.os-s{outline-style:solid}
+.os-t{outline-style:thin}
+.os-m{outline-style:medium}
+.os-k{outline-style:thick}
 
     </code>
   </pre>
@@ -37,10 +39,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.outline-style@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.outline-style@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/outline-width/README.md
+++ b/packages/outline-width/README.md
@@ -1,0 +1,40 @@
+# minions.outline-width
+minions outline-width classes
+
+## Module
+name: `minions.minions.outline-width`  
+version: `0.0.4-alpha-10`  
+main/style: `outline-width.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.outline-width@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.outline-width@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ow-0,.ow-1p,.ow-2p,.ow-3p,.ow-4p{outline-style:solid}
+.ow-0{outline-width:0}
+.ow-1p{outline-width:1px}
+.ow-2p{outline-width:2px}
+.ow-3p{outline-width:3px}
+.ow-4p{outline-width:4px}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/outline-width
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/outline-width/index.html
+++ b/packages/outline-width/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.outline-width | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.outline-width</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/outline-width">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ow-0,.ow-1p,.ow-2p,.ow-3p,.ow-4p{outline-style:solid}
+.ow-0{outline-width:0}
+.ow-1p{outline-width:1px}
+.ow-2p{outline-width:2px}
+.ow-3p{outline-width:3px}
+.ow-4p{outline-width:4px}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.outline-width@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.outline-width@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/overflow-wrap/README.md
+++ b/packages/overflow-wrap/README.md
@@ -1,0 +1,36 @@
+# minions.overflow-wrap
+minions overflow-wrap classes
+
+## Module
+name: `minions.minions.overflow-wrap`  
+version: `0.0.4-alpha-10`  
+main/style: `overflow-wrap.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.overflow-wrap@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.overflow-wrap@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ow-n{overflow-wrap:normal}
+.ow-bw{overflow-wrap:break-word}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/overflow-wrap
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/overflow-wrap/index.html
+++ b/packages/overflow-wrap/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.overflow-wrap | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.overflow-wrap</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/overflow-wrap">
     source on Github
   </a>
 
@@ -23,12 +23,9 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ow-n{overflow-wrap:normal}
+.ow-bw{overflow-wrap:break-word}
 
     </code>
   </pre>
@@ -37,10 +34,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.overflow-wrap@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.overflow-wrap@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/overflow-x/README.md
+++ b/packages/overflow-x/README.md
@@ -1,0 +1,38 @@
+# minions.overflow-x
+minions overflow-x classes
+
+## Module
+name: `minions.minions.overflow-x`  
+version: `0.0.4-alpha-10`  
+main/style: `overflow-x.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.overflow-x@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.overflow-x@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ox-a{overflow-x:auto}
+.ox-h{overflow-x:hidden}
+.ox-s{overflow-x:scroll}
+.ox-v{overflow-x:visible}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/overflow-x
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/overflow-x/index.html
+++ b/packages/overflow-x/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.overflow-x | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.overflow-x</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/overflow-x">
     source on Github
   </a>
 
@@ -23,12 +23,11 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ox-a{overflow-x:auto}
+.ox-h{overflow-x:hidden}
+.ox-s{overflow-x:scroll}
+.ox-v{overflow-x:visible}
 
     </code>
   </pre>
@@ -37,10 +36,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.overflow-x@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.overflow-x@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/overflow-y/README.md
+++ b/packages/overflow-y/README.md
@@ -1,0 +1,38 @@
+# minions.overflow-y
+minions overflow-y classes
+
+## Module
+name: `minions.minions.overflow-y`  
+version: `0.0.4-alpha-10`  
+main/style: `overflow-y.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.overflow-y@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.overflow-y@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.oy-a{overflow-y:auto}
+.oy-h{overflow-y:hidden}
+.oy-s{overflow-y:scroll}
+.oy-v{overflow-y:visible}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/overflow-y
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/overflow-y/index.html
+++ b/packages/overflow-y/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.overflow-y | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.overflow-y</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/overflow-y">
     source on Github
   </a>
 
@@ -23,12 +23,11 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.oy-a{overflow-y:auto}
+.oy-h{overflow-y:hidden}
+.oy-s{overflow-y:scroll}
+.oy-v{overflow-y:visible}
 
     </code>
   </pre>
@@ -37,10 +36,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.overflow-y@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.overflow-y@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/overflow/README.md
+++ b/packages/overflow/README.md
@@ -1,0 +1,39 @@
+# minions.overflow
+minions overflow classes
+
+## Module
+name: `minions.minions.overflow`  
+version: `0.0.4-alpha-10`  
+main/style: `overflow.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.overflow@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.overflow@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.o-a{overflow:auto}
+.o-h{overflow:hidden}
+.o-s{overflow:scroll}
+.o-v{overflow:visible}
+.-wos-t{overflow:scroll;-webkit-overflow-scrolling:touch}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/overflow
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/overflow/index.html
+++ b/packages/overflow/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.overflow | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.overflow</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/overflow">
     source on Github
   </a>
 
@@ -23,12 +23,12 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.o-a{overflow:auto}
+.o-h{overflow:hidden}
+.o-s{overflow:scroll}
+.o-v{overflow:visible}
+.-wos-t{overflow:scroll;-webkit-overflow-scrolling:touch}
 
     </code>
   </pre>
@@ -37,10 +37,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.overflow@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.overflow@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/padding-bottom/README.md
+++ b/packages/padding-bottom/README.md
@@ -1,0 +1,47 @@
+# minions.padding-bottom
+minions padding-bottom classes
+
+## Module
+name: `minions.minions.padding-bottom`  
+version: `0.0.4-alpah-13`  
+main/style: `padding-bottom.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.padding-bottom@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.padding-bottom@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.pb-0{padding-bottom:0}
+.pb-\.25e{padding-bottom:.25em}
+.pb-\.5e{padding-bottom:.5em}
+.pb-1e{padding-bottom:1em}
+.pb-2e{padding-bottom:2em}
+.pb-3e{padding-bottom:3em}
+.pb-4e{padding-bottom:4em}
+.pb-\.25r{padding-bottom:.25rem}
+.pb-\.5r{padding-bottom:.5rem}
+.pb-1r{padding-bottom:1rem}
+.pb-2r{padding-bottom:2rem}
+.pb-3r{padding-bottom:3rem}
+.pb-4r{padding-bottom:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding-bottom
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/padding-bottom/index.html
+++ b/packages/padding-bottom/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.padding-bottom | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.padding-bottom</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding-bottom">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.pb-0{padding-bottom:0}
+.pb-\.25e{padding-bottom:.25em}
+.pb-\.5e{padding-bottom:.5em}
+.pb-1e{padding-bottom:1em}
+.pb-2e{padding-bottom:2em}
+.pb-3e{padding-bottom:3em}
+.pb-4e{padding-bottom:4em}
+.pb-\.25r{padding-bottom:.25rem}
+.pb-\.5r{padding-bottom:.5rem}
+.pb-1r{padding-bottom:1rem}
+.pb-2r{padding-bottom:2rem}
+.pb-3r{padding-bottom:3rem}
+.pb-4r{padding-bottom:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.padding-bottom@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.padding-bottom@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/padding-left/README.md
+++ b/packages/padding-left/README.md
@@ -1,0 +1,47 @@
+# minions.padding-left
+minions padding-left classes
+
+## Module
+name: `minions.minions.padding-left`  
+version: `0.0.4-alpah-13`  
+main/style: `padding-left.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.padding-left@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.padding-left@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.pl-0{padding-left:0}
+.pl-\.25e{padding-left:.25em}
+.pl-\.5e{padding-left:.5em}
+.pl-1e{padding-left:1em}
+.pl-2e{padding-left:2em}
+.pl-3e{padding-left:3em}
+.pl-4e{padding-left:4em}
+.pl-\.25r{padding-left:.25rem}
+.pl-\.5r{padding-left:.5rem}
+.pl-1r{padding-left:1rem}
+.pl-2r{padding-left:2rem}
+.pl-3r{padding-left:3rem}
+.pl-4r{padding-left:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding-left
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/padding-left/index.html
+++ b/packages/padding-left/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.padding-left | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.padding-left</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding-left">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.pl-0{padding-left:0}
+.pl-\.25e{padding-left:.25em}
+.pl-\.5e{padding-left:.5em}
+.pl-1e{padding-left:1em}
+.pl-2e{padding-left:2em}
+.pl-3e{padding-left:3em}
+.pl-4e{padding-left:4em}
+.pl-\.25r{padding-left:.25rem}
+.pl-\.5r{padding-left:.5rem}
+.pl-1r{padding-left:1rem}
+.pl-2r{padding-left:2rem}
+.pl-3r{padding-left:3rem}
+.pl-4r{padding-left:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.padding-left@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.padding-left@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/padding-right/README.md
+++ b/packages/padding-right/README.md
@@ -1,0 +1,47 @@
+# minions.padding-right
+minions padding-right classes
+
+## Module
+name: `minions.minions.padding-right`  
+version: `0.0.4-alpah-13`  
+main/style: `padding-right.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.padding-right@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.padding-right@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.pr-0{padding-right:0}
+.pr-\.25e{padding-right:.25em}
+.pr-\.5e{padding-right:.5em}
+.pr-1e{padding-right:1em}
+.pr-2e{padding-right:2em}
+.pr-3e{padding-right:3em}
+.pr-4e{padding-right:4em}
+.pr-\.25r{padding-right:.25rem}
+.pr-\.5r{padding-right:.5rem}
+.pr-1r{padding-right:1rem}
+.pr-2r{padding-right:2rem}
+.pr-3r{padding-right:3rem}
+.pr-4r{padding-right:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding-right
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/padding-right/index.html
+++ b/packages/padding-right/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.padding-right | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.padding-right</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding-right">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.pr-0{padding-right:0}
+.pr-\.25e{padding-right:.25em}
+.pr-\.5e{padding-right:.5em}
+.pr-1e{padding-right:1em}
+.pr-2e{padding-right:2em}
+.pr-3e{padding-right:3em}
+.pr-4e{padding-right:4em}
+.pr-\.25r{padding-right:.25rem}
+.pr-\.5r{padding-right:.5rem}
+.pr-1r{padding-right:1rem}
+.pr-2r{padding-right:2rem}
+.pr-3r{padding-right:3rem}
+.pr-4r{padding-right:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.padding-right@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.padding-right@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/padding-top/README.md
+++ b/packages/padding-top/README.md
@@ -1,0 +1,47 @@
+# minions.padding-top
+minions padding-top classes
+
+## Module
+name: `minions.minions.padding-top`  
+version: `0.0.4-alpah-13`  
+main/style: `padding-top.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.padding-top@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.padding-top@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.pt-0{padding-top:0}
+.pt-\.25e{padding-top:.25em}
+.pt-\.5e{padding-top:.5em}
+.pt-1e{padding-top:1em}
+.pt-2e{padding-top:2em}
+.pt-3e{padding-top:3em}
+.pt-4e{padding-top:4em}
+.pt-\.25r{padding-top:.25rem}
+.pt-\.5r{padding-top:.5rem}
+.pt-1r{padding-top:1rem}
+.pt-2r{padding-top:2rem}
+.pt-3r{padding-top:3rem}
+.pt-4r{padding-top:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding-top
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/padding-top/index.html
+++ b/packages/padding-top/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.padding-top | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.padding-top</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding-top">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.pt-0{padding-top:0}
+.pt-\.25e{padding-top:.25em}
+.pt-\.5e{padding-top:.5em}
+.pt-1e{padding-top:1em}
+.pt-2e{padding-top:2em}
+.pt-3e{padding-top:3em}
+.pt-4e{padding-top:4em}
+.pt-\.25r{padding-top:.25rem}
+.pt-\.5r{padding-top:.5rem}
+.pt-1r{padding-top:1rem}
+.pt-2r{padding-top:2rem}
+.pt-3r{padding-top:3rem}
+.pt-4r{padding-top:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.padding-top@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.padding-top@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/padding-x/README.md
+++ b/packages/padding-x/README.md
@@ -1,0 +1,47 @@
+# minions.padding-x
+minions padding-x classes
+
+## Module
+name: `minions.minions.padding-x`  
+version: `0.0.4-alpah-13`  
+main/style: `padding-x.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.padding-x@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.padding-x@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.px-0{padding-right:0;padding-left:0}
+.px-\.25e{padding-right:.25em;padding-left:.25em}
+.px-\.5e{padding-right:.5em;padding-left:.5em}
+.px-1e{padding-right:1em;padding-left:1em}
+.px-2e{padding-right:2em;padding-left:2em}
+.px-3e{padding-right:3em;padding-left:3em}
+.px-4e{padding-right:4em;padding-left:4em}
+.px-\.25r{padding-right:.25rem;padding-left:.25rem}
+.px-\.5r{padding-right:.5rem;padding-left:.5rem}
+.px-1r{padding-right:1rem;padding-left:1rem}
+.px-2r{padding-right:2rem;padding-left:2rem}
+.px-3r{padding-right:3rem;padding-left:3rem}
+.px-4r{padding-right:4rem;padding-left:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding-x
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/padding-x/index.html
+++ b/packages/padding-x/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.padding-x | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.padding-x</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding-x">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.px-0{padding-right:0;padding-left:0}
+.px-\.25e{padding-right:.25em;padding-left:.25em}
+.px-\.5e{padding-right:.5em;padding-left:.5em}
+.px-1e{padding-right:1em;padding-left:1em}
+.px-2e{padding-right:2em;padding-left:2em}
+.px-3e{padding-right:3em;padding-left:3em}
+.px-4e{padding-right:4em;padding-left:4em}
+.px-\.25r{padding-right:.25rem;padding-left:.25rem}
+.px-\.5r{padding-right:.5rem;padding-left:.5rem}
+.px-1r{padding-right:1rem;padding-left:1rem}
+.px-2r{padding-right:2rem;padding-left:2rem}
+.px-3r{padding-right:3rem;padding-left:3rem}
+.px-4r{padding-right:4rem;padding-left:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.padding-x@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.padding-x@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/padding-y/README.md
+++ b/packages/padding-y/README.md
@@ -1,0 +1,47 @@
+# minions.padding-y
+minions padding-y classes
+
+## Module
+name: `minions.minions.padding-y`  
+version: `0.0.4-alpah-13`  
+main/style: `padding-y.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.padding-y@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.padding-y@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.py-0{padding-top:0;padding-bottom:0}
+.py-\.25e{padding-top:.25em;padding-bottom:.25em}
+.py-\.5e{padding-top:.5em;padding-bottom:.5em}
+.py-1e{padding-top:1em;padding-bottom:1em}
+.py-2e{padding-top:2em;padding-bottom:2em}
+.py-3e{padding-top:3em;padding-bottom:3em}
+.py-4e{padding-top:4em;padding-bottom:4em}
+.py-\.25r{padding-top:.25rem;padding-bottom:.25rem}
+.py-\.5r{padding-top:.5rem;padding-bottom:.5rem}
+.py-1r{padding-top:1rem;padding-bottom:1rem}
+.py-2r{padding-top:2rem;padding-bottom:2rem}
+.py-3r{padding-top:3rem;padding-bottom:3rem}
+.py-4r{padding-top:4rem;padding-bottom:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding-y
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/padding-y/index.html
+++ b/packages/padding-y/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.padding-y | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.padding-y</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding-y">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.py-0{padding-top:0;padding-bottom:0}
+.py-\.25e{padding-top:.25em;padding-bottom:.25em}
+.py-\.5e{padding-top:.5em;padding-bottom:.5em}
+.py-1e{padding-top:1em;padding-bottom:1em}
+.py-2e{padding-top:2em;padding-bottom:2em}
+.py-3e{padding-top:3em;padding-bottom:3em}
+.py-4e{padding-top:4em;padding-bottom:4em}
+.py-\.25r{padding-top:.25rem;padding-bottom:.25rem}
+.py-\.5r{padding-top:.5rem;padding-bottom:.5rem}
+.py-1r{padding-top:1rem;padding-bottom:1rem}
+.py-2r{padding-top:2rem;padding-bottom:2rem}
+.py-3r{padding-top:3rem;padding-bottom:3rem}
+.py-4r{padding-top:4rem;padding-bottom:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.padding-y@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.padding-y@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/padding/README.md
+++ b/packages/padding/README.md
@@ -1,0 +1,47 @@
+# minions.padding
+minions padding classes
+
+## Module
+name: `minions.minions.padding`  
+version: `0.0.4-alpah-13`  
+main/style: `padding.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.padding@0.0.4-alpah-13
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.padding@0.0.4-alpah-13" />
+```
+
+## Code
+```css
+/*! minions.css */
+.p-0{padding:0}
+.p-\.25e{padding:.25em}
+.p-\.5e{padding:.5em}
+.p-1e{padding:1em}
+.p-2e{padding:2em}
+.p-3e{padding:3em}
+.p-4e{padding:4em}
+.p-\.25r{padding:.25rem}
+.p-\.5r{padding:.5rem}
+.p-1r{padding:1rem}
+.p-2r{padding:2rem}
+.p-3r{padding:3rem}
+.p-4r{padding:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/padding/index.html
+++ b/packages/padding/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.padding | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.padding</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/padding">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.p-0{padding:0}
+.p-\.25e{padding:.25em}
+.p-\.5e{padding:.5em}
+.p-1e{padding:1em}
+.p-2e{padding:2em}
+.p-3e{padding:3em}
+.p-4e{padding:4em}
+.p-\.25r{padding:.25rem}
+.p-\.5r{padding:.5rem}
+.p-1r{padding:1rem}
+.p-2r{padding:2rem}
+.p-3r{padding:3rem}
+.p-4r{padding:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.padding@0.0.4-alpah-13</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.padding@0.0.4-alpah-13" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/pointer-events/README.md
+++ b/packages/pointer-events/README.md
@@ -1,0 +1,43 @@
+# minions.pointer-events
+minions pointer-events classes
+
+## Module
+name: `minions.minions.pointer-events`  
+version: `0.0.4-alpha-10`  
+main/style: `pointer-events.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.pointer-events@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.pointer-events@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.pe-n{pointer-events:none}
+.pe-vP{pointer-events:visiblePainted}
+.pe-vF{pointer-events:visibleFill}
+.pe-vS{pointer-events:visibleStroke}
+.pe-v{pointer-events:visible}
+.pe-p{pointer-events:painted}
+.pe-f{pointer-events:fill}
+.pe-s{pointer-events:stroke}
+.pe-a{pointer-events:all}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/pointer-events
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/pointer-events/index.html
+++ b/packages/pointer-events/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.pointer-events | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.pointer-events</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/pointer-events">
     source on Github
   </a>
 
@@ -23,12 +23,16 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.pe-n{pointer-events:none}
+.pe-vP{pointer-events:visiblePainted}
+.pe-vF{pointer-events:visibleFill}
+.pe-vS{pointer-events:visibleStroke}
+.pe-v{pointer-events:visible}
+.pe-p{pointer-events:painted}
+.pe-f{pointer-events:fill}
+.pe-s{pointer-events:stroke}
+.pe-a{pointer-events:all}
 
     </code>
   </pre>
@@ -37,10 +41,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.pointer-events@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.pointer-events@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/position/README.md
+++ b/packages/position/README.md
@@ -1,0 +1,38 @@
+# minions.position
+minions position classes
+
+## Module
+name: `minions.minions.position`  
+version: `0.0.4-alpha-4`  
+main/style: `position.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.position@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.position@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.p-s{position:static}
+.p-r{position:relative}
+.p-a{position:absolute}
+.p-f{position:fixed}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/position
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/position/index.html
+++ b/packages/position/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.position | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.position</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/position">
     source on Github
   </a>
 
@@ -23,12 +23,11 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.p-s{position:static}
+.p-r{position:relative}
+.p-a{position:absolute}
+.p-f{position:fixed}
 
     </code>
   </pre>
@@ -37,10 +36,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.position@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.position@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/resize/README.md
+++ b/packages/resize/README.md
@@ -1,0 +1,40 @@
+# minions.resize
+minions resize classes
+
+## Module
+name: `minions.minions.resize`  
+version: `0.0.4-alpha-10`  
+main/style: `resize.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.resize@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.resize@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.r-n{resize:none}
+.r-b{resize:both}
+.r-h{resize:horizontal}
+.r-v{resize:vertical}
+.r-b{resize:block}
+.r-i{resize:inline}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/resize
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/resize/index.html
+++ b/packages/resize/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.resize | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.resize</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/resize">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.r-n{resize:none}
+.r-b{resize:both}
+.r-h{resize:horizontal}
+.r-v{resize:vertical}
+.r-b{resize:block}
+.r-i{resize:inline}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.resize@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.resize@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/right/README.md
+++ b/packages/right/README.md
@@ -1,0 +1,51 @@
+# minions.right
+minions right classes
+
+## Module
+name: `minions.minions.right`  
+version: `0.0.4-alpha-4`  
+main/style: `right.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.right@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.right@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.r-0{right:0}
+.r-1p{right:1px}
+.r-2p{right:1px}
+.r-3p{right:3px}
+.r-4p{right:4px}
+.r-\.25{right:.25em}
+.r-\.5{right:.5em}
+.r-1{right:1em}
+.r-2{right:2em}
+.r-3{right:3em}
+.r-4{right:4em}
+.r-\.25r{right:.25em}
+.r-\.5r{right:.5em}
+.r-1r{right:1em}
+.r-2r{right:2em}
+.r-3r{right:3em}
+.r-4r{right:4em}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/right
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/right/index.html
+++ b/packages/right/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.right | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.right</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/right">
     source on Github
   </a>
 
@@ -23,12 +23,24 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.r-0{right:0}
+.r-1p{right:1px}
+.r-2p{right:1px}
+.r-3p{right:3px}
+.r-4p{right:4px}
+.r-\.25{right:.25em}
+.r-\.5{right:.5em}
+.r-1{right:1em}
+.r-2{right:2em}
+.r-3{right:3em}
+.r-4{right:4em}
+.r-\.25r{right:.25em}
+.r-\.5r{right:.5em}
+.r-1r{right:1em}
+.r-2r{right:2em}
+.r-3r{right:3em}
+.r-4r{right:4em}
 
     </code>
   </pre>
@@ -37,10 +49,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.right@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.right@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/text-align/README.md
+++ b/packages/text-align/README.md
@@ -1,0 +1,38 @@
+# minions.text-align
+minions text-align classes
+
+## Module
+name: `minions.minions.text-align`  
+version: `0.0.4-alpha-4`  
+main/style: `text-align.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.text-align@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.text-align@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ta-c{text-align:center}
+.ta-j{text-align:justify}
+.ta-l{text-align:left}
+.ta-r{text-align:right}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/text-align
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/text-align/index.html
+++ b/packages/text-align/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.text-align | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.text-align</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/text-align">
     source on Github
   </a>
 
@@ -23,12 +23,11 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ta-c{text-align:center}
+.ta-j{text-align:justify}
+.ta-l{text-align:left}
+.ta-r{text-align:right}
 
     </code>
   </pre>
@@ -37,10 +36,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.text-align@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.text-align@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/text-decoration/README.md
+++ b/packages/text-decoration/README.md
@@ -1,0 +1,37 @@
+# minions.text-decoration
+minions text-decoration classes
+
+## Module
+name: `minions.minions.text-decoration`  
+version: `0.0.4-alpha-4`  
+main/style: `text-decoration.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.text-decoration@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.text-decoration@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.td-u{text-decoration:underline}
+.td-o{text-decoration:overline}
+.td-n{text-decoration:none}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/text-decoration
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/text-decoration/index.html
+++ b/packages/text-decoration/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.text-decoration | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.text-decoration</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/text-decoration">
     source on Github
   </a>
 
@@ -23,12 +23,10 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.td-u{text-decoration:underline}
+.td-o{text-decoration:overline}
+.td-n{text-decoration:none}
 
     </code>
   </pre>
@@ -37,10 +35,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.text-decoration@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.text-decoration@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/text-indent/README.md
+++ b/packages/text-indent/README.md
@@ -1,0 +1,47 @@
+# minions.text-indent
+minions text-indent classes
+
+## Module
+name: `minions.minions.text-indent`  
+version: `0.0.4-alpha-10`  
+main/style: `text-indent.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.text-indent@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.text-indent@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ti-0{text-indent:0}
+.ti-\.25e{text-indent:.25em}
+.ti-\.5e{text-indent:.5em}
+.ti-1e{text-indent:1em}
+.ti-2e{text-indent:2em}
+.ti-3e{text-indent:3em}
+.ti-4e{text-indent:4em}
+.ti-\.25r{text-indent:.25rem}
+.ti-\.5r{text-indent:.5rem}
+.ti-1r{text-indent:1rem}
+.ti-2r{text-indent:2rem}
+.ti-3r{text-indent:3rem}
+.ti-4r{text-indent:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/text-indent
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/text-indent/index.html
+++ b/packages/text-indent/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.text-indent | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.text-indent</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/text-indent">
     source on Github
   </a>
 
@@ -23,12 +23,20 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ti-0{text-indent:0}
+.ti-\.25e{text-indent:.25em}
+.ti-\.5e{text-indent:.5em}
+.ti-1e{text-indent:1em}
+.ti-2e{text-indent:2em}
+.ti-3e{text-indent:3em}
+.ti-4e{text-indent:4em}
+.ti-\.25r{text-indent:.25rem}
+.ti-\.5r{text-indent:.5rem}
+.ti-1r{text-indent:1rem}
+.ti-2r{text-indent:2rem}
+.ti-3r{text-indent:3rem}
+.ti-4r{text-indent:4rem}
 
     </code>
   </pre>
@@ -37,10 +45,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.text-indent@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.text-indent@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/text-overflow/README.md
+++ b/packages/text-overflow/README.md
@@ -1,0 +1,36 @@
+# minions.text-overflow
+minions text-overflow classes
+
+## Module
+name: `minions.minions.text-overflow`  
+version: `0.0.4-alpha-4`  
+main/style: `text-overflow.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.text-overflow@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.text-overflow@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.to-c{text-overflow:clip}
+.to-e{text-overflow:ellipsis}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/text-overflow
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/text-overflow/index.html
+++ b/packages/text-overflow/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.text-overflow | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.text-overflow</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/text-overflow">
     source on Github
   </a>
 
@@ -23,12 +23,9 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.to-c{text-overflow:clip}
+.to-e{text-overflow:ellipsis}
 
     </code>
   </pre>
@@ -37,10 +34,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.text-overflow@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.text-overflow@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/text-transform/README.md
+++ b/packages/text-transform/README.md
@@ -1,0 +1,40 @@
+# minions.text-transform
+minions text-transform classes
+
+## Module
+name: `minions.minions.text-transform`  
+version: `0.0.4-alpha-4`  
+main/style: `text-transform.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.text-transform@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.text-transform@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.tt-c{text-transform:capitalize}
+.tt-u{text-transform:uppercase}
+.tt-l{text-transform:lowercase}
+.tt-n{text-transform:none}
+.tt-fw{text-transform:full-width}
+.tt-i{text-transform:initial}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/text-transform
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/text-transform/index.html
+++ b/packages/text-transform/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.text-transform | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.text-transform</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/text-transform">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.tt-c{text-transform:capitalize}
+.tt-u{text-transform:uppercase}
+.tt-l{text-transform:lowercase}
+.tt-n{text-transform:none}
+.tt-fw{text-transform:full-width}
+.tt-i{text-transform:initial}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.text-transform@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.text-transform@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/top/README.md
+++ b/packages/top/README.md
@@ -1,0 +1,51 @@
+# minions.top
+minions top classes
+
+## Module
+name: `minions.minions.top`  
+version: `0.0.4-alpha-4`  
+main/style: `top.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.top@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.top@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.t-0{top:0}
+.t-1p{top:1px}
+.t-2p{top:1px}
+.t-3p{top:3px}
+.t-4p{top:4px}
+.t-\.25e{top:.25em}
+.t-\.5e{top:.5em}
+.t-1e{top:1em}
+.t-2e{top:2em}
+.t-3e{top:3em}
+.t-4e{top:4em}
+.t-\.25r{top:.25rem}
+.t-\.5r{top:.5rem}
+.t-1r{top:1rem}
+.t-2r{top:2rem}
+.t-3r{top:3rem}
+.t-4r{top:4rem}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/top
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/top/index.html
+++ b/packages/top/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.top | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.top</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/top">
     source on Github
   </a>
 
@@ -23,12 +23,24 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.t-0{top:0}
+.t-1p{top:1px}
+.t-2p{top:1px}
+.t-3p{top:3px}
+.t-4p{top:4px}
+.t-\.25e{top:.25em}
+.t-\.5e{top:.5em}
+.t-1e{top:1em}
+.t-2e{top:2em}
+.t-3e{top:3em}
+.t-4e{top:4em}
+.t-\.25r{top:.25rem}
+.t-\.5r{top:.5rem}
+.t-1r{top:1rem}
+.t-2r{top:2rem}
+.t-3r{top:3rem}
+.t-4r{top:4rem}
 
     </code>
   </pre>
@@ -37,10 +49,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.top@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.top@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/transition-delay/README.md
+++ b/packages/transition-delay/README.md
@@ -1,0 +1,44 @@
+# minions.transition-delay
+minions transition-delay classes
+
+## Module
+name: `minions.minions.transition-delay`  
+version: `0.0.4-alpha-10`  
+main/style: `transition-delay.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.transition-delay@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.transition-delay@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ty-1s{transition-delay:1s}
+.ty-\.9s{transition-delay:.9s}
+.ty-\.8s{transition-delay:.8s}
+.ty-\.7s{transition-delay:.7s}
+.ty-\.6s{transition-delay:.6s}
+.ty-\.5s{transition-delay:.5s}
+.ty-\.4s{transition-delay:.4s}
+.ty-\.3s{transition-delay:.3s}
+.ty-\.2s{transition-delay:.2s}
+.ty-\.1s{transition-delay:.1s}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/transition-delay
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/transition-delay/index.html
+++ b/packages/transition-delay/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.transition-delay | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.transition-delay</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/transition-delay">
     source on Github
   </a>
 
@@ -23,12 +23,17 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ty-1s{transition-delay:1s}
+.ty-\.9s{transition-delay:.9s}
+.ty-\.8s{transition-delay:.8s}
+.ty-\.7s{transition-delay:.7s}
+.ty-\.6s{transition-delay:.6s}
+.ty-\.5s{transition-delay:.5s}
+.ty-\.4s{transition-delay:.4s}
+.ty-\.3s{transition-delay:.3s}
+.ty-\.2s{transition-delay:.2s}
+.ty-\.1s{transition-delay:.1s}
 
     </code>
   </pre>
@@ -37,10 +42,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.transition-delay@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.transition-delay@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/transition-duration/README.md
+++ b/packages/transition-duration/README.md
@@ -1,0 +1,44 @@
+# minions.transition-duration
+minions transition-duration classes
+
+## Module
+name: `minions.minions.transition-duration`  
+version: `0.0.4-alpha-4`  
+main/style: `transition-duration.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.transition-duration@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.transition-duration@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.td-1s{transition-duration:1s}
+.td-\.9s{transition-duration:.9s}
+.td-\.8s{transition-duration:.8s}
+.td-\.7s{transition-duration:.7s}
+.td-\.6s{transition-duration:.6s}
+.td-\.5s{transition-duration:.5s}
+.td-\.4s{transition-duration:.4s}
+.td-\.3s{transition-duration:.3s}
+.td-\.2s{transition-duration:.2s}
+.td-\.1s{transition-duration:.1s}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/transition-duration
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/transition-duration/index.html
+++ b/packages/transition-duration/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.transition-duration | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.transition-duration</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/transition-duration">
     source on Github
   </a>
 
@@ -23,12 +23,17 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.td-1s{transition-duration:1s}
+.td-\.9s{transition-duration:.9s}
+.td-\.8s{transition-duration:.8s}
+.td-\.7s{transition-duration:.7s}
+.td-\.6s{transition-duration:.6s}
+.td-\.5s{transition-duration:.5s}
+.td-\.4s{transition-duration:.4s}
+.td-\.3s{transition-duration:.3s}
+.td-\.2s{transition-duration:.2s}
+.td-\.1s{transition-duration:.1s}
 
     </code>
   </pre>
@@ -37,10 +42,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.transition-duration@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.transition-duration@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/transition-property/README.md
+++ b/packages/transition-property/README.md
@@ -1,0 +1,37 @@
+# minions.transition-property
+minions transition-property classes
+
+## Module
+name: `minions.minions.transition-property`  
+version: `0.0.4-alpha-4`  
+main/style: `transition-property.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.transition-property@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.transition-property@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.tp-a { transition-property: all }
+.tp-n { transition-property: none }
+.tp-o { transform-property: opacity }
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/transition-property
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/transition-property/index.html
+++ b/packages/transition-property/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.transition-property | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.transition-property</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/transition-property">
     source on Github
   </a>
 
@@ -23,12 +23,10 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.tp-a { transition-property: all }
+.tp-n { transition-property: none }
+.tp-o { transform-property: opacity }
 
     </code>
   </pre>
@@ -37,10 +35,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.transition-property@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.transition-property@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/transition-timing-function/README.md
+++ b/packages/transition-timing-function/README.md
@@ -1,0 +1,41 @@
+# minions.transition-timing-function
+minions transition-timing-function classes
+
+## Module
+name: `minions.minions.transition-timing-function`  
+version: `0.0.4-alpha-4`  
+main/style: `transition-timing-function.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.transition-timing-function@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.transition-timing-function@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ttf-l{transition-timing-function:linear}
+.ttf-e{transition-timing-function:ease}
+.ttf-ei{transition-timing-function:ease-in}
+.ttf-eio{transition-timing-function:ease-in-out}
+.ttf-eo{transition-timing-function:ease-out}
+.ttf-ss{transition-timing-function:step-start}
+.ttf-se{transition-timing-function:step-end}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/transition-timing-function
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/transition-timing-function/index.html
+++ b/packages/transition-timing-function/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.transition-timing-function | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.transition-timing-function</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/transition-timing-function">
     source on Github
   </a>
 
@@ -23,12 +23,14 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ttf-l{transition-timing-function:linear}
+.ttf-e{transition-timing-function:ease}
+.ttf-ei{transition-timing-function:ease-in}
+.ttf-eio{transition-timing-function:ease-in-out}
+.ttf-eo{transition-timing-function:ease-out}
+.ttf-ss{transition-timing-function:step-start}
+.ttf-se{transition-timing-function:step-end}
 
     </code>
   </pre>
@@ -37,10 +39,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.transition-timing-function@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.transition-timing-function@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/vertical-align/README.md
+++ b/packages/vertical-align/README.md
@@ -1,0 +1,40 @@
+# minions.vertical-align
+minions vertical-align classes
+
+## Module
+name: `minions.minions.vertical-align`  
+version: `0.0.4-alpha-4`  
+main/style: `vertical-align.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.vertical-align@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.vertical-align@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.va-l{vertical-align:baseline}
+.va-tt{vertical-align:text-top}
+.va-tb{vertical-align:text-bottom}
+.va-m{vertical-align:middle}
+.va-t{vertical-align:top}
+.va-b{vertical-align:bottom}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/vertical-align
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/vertical-align/index.html
+++ b/packages/vertical-align/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.vertical-align | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.vertical-align</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/vertical-align">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.va-l{vertical-align:baseline}
+.va-tt{vertical-align:text-top}
+.va-tb{vertical-align:text-bottom}
+.va-m{vertical-align:middle}
+.va-t{vertical-align:top}
+.va-b{vertical-align:bottom}
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.vertical-align@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.vertical-align@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/visibility/README.md
+++ b/packages/visibility/README.md
@@ -1,0 +1,36 @@
+# minions.visibility
+minions visibility classes
+
+## Module
+name: `minions.minions.visibility`  
+version: `0.0.4-alpha-4`  
+main/style: `visibility.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.visibility@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.visibility@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.v-h{visibility:hidden}
+.v-v{visibility:visible}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/visibility
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/visibility/index.html
+++ b/packages/visibility/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.visibility | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.visibility</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/visibility">
     source on Github
   </a>
 
@@ -23,12 +23,9 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.v-h{visibility:hidden}
+.v-v{visibility:visible}
 
     </code>
   </pre>
@@ -37,10 +34,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.visibility@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.visibility@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/white-space/README.md
+++ b/packages/white-space/README.md
@@ -1,0 +1,38 @@
+# minions.white-space
+minions white-space classes
+
+## Module
+name: `minions.minions.white-space`  
+version: `0.0.4-alpha-4`  
+main/style: `white-space.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.white-space@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.white-space@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ws-n{white-space: nowrap}
+.ws-p{white-space: pre}
+.ws-pw{white-space: pre-wrap}
+.ws-pl{white-space: pre-line}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/white-space
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/white-space/index.html
+++ b/packages/white-space/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.white-space | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.white-space</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/white-space">
     source on Github
   </a>
 
@@ -23,12 +23,11 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ws-n{white-space: nowrap}
+.ws-p{white-space: pre}
+.ws-pw{white-space: pre-wrap}
+.ws-pl{white-space: pre-line}
 
     </code>
   </pre>
@@ -37,10 +36,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.white-space@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.white-space@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/width/README.md
+++ b/packages/width/README.md
@@ -1,0 +1,52 @@
+# minions.width
+minions width classes
+
+## Module
+name: `minions.minions.width`  
+version: `0.0.4-alpha-4`  
+main/style: `width.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.width@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.width@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.w-a{width:auto}
+.w-mc{width:max-content}
+.w-nc{width:min-content}
+.w-fc{width:fit-content}
+.w-10\%{width:10%}
+.w-20\%{width:20%}
+.w-25\%{width:25%}
+.w-30\%{width:30%}
+.w-33\%{width:33.3333%}
+.w-40\%{width:40%}
+.w-50\%{width:50%}
+.w-60\%{width:60%}
+.w-66\%{width:66.6666%}
+.w-70\%{width:70%}
+.w-75\%{width:75%}
+.w-80\%{width:80%}
+.w-90\%{width:90%}
+.w-100\%{width:100%}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/width
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/width/index.html
+++ b/packages/width/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.width | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.width</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/width">
     source on Github
   </a>
 
@@ -23,12 +23,25 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.w-a{width:auto}
+.w-mc{width:max-content}
+.w-nc{width:min-content}
+.w-fc{width:fit-content}
+.w-10\%{width:10%}
+.w-20\%{width:20%}
+.w-25\%{width:25%}
+.w-30\%{width:30%}
+.w-33\%{width:33.3333%}
+.w-40\%{width:40%}
+.w-50\%{width:50%}
+.w-60\%{width:60%}
+.w-66\%{width:66.6666%}
+.w-70\%{width:70%}
+.w-75\%{width:75%}
+.w-80\%{width:80%}
+.w-90\%{width:90%}
+.w-100\%{width:100%}
 
     </code>
   </pre>
@@ -37,10 +50,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.width@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.width@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/will-change/README.md
+++ b/packages/will-change/README.md
@@ -1,0 +1,40 @@
+# minions.will-change
+minions will-change classes
+
+## Module
+name: `minions.minions.will-change`  
+version: `0.0.4-alpha-10`  
+main/style: `will-change.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.will-change@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.will-change@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.wc-a{will-change:auto}
+.wc-sp{will-change:scroll-position}
+.wc-c{will-change:contents}
+.wc-t{will-change:transform}
+.wc-o{will-change:opacity}
+/* only performant custom-indent by default */
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/will-change
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/will-change/index.html
+++ b/packages/will-change/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.will-change | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.will-change</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/will-change">
     source on Github
   </a>
 
@@ -23,12 +23,13 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.wc-a{will-change:auto}
+.wc-sp{will-change:scroll-position}
+.wc-c{will-change:contents}
+.wc-t{will-change:transform}
+.wc-o{will-change:opacity}
+/* only performant custom-indent by default */
 
     </code>
   </pre>
@@ -37,10 +38,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.will-change@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.will-change@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/word-break/README.md
+++ b/packages/word-break/README.md
@@ -1,0 +1,37 @@
+# minions.word-break
+minions word-break classes
+
+## Module
+name: `minions.minions.word-break`  
+version: `0.0.4-alpha-10`  
+main/style: `word-break.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.word-break@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.word-break@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.wb-n{word-break:normal} 
+.wb-ba{word-break:break-all}
+.wb-ka{word-break:keep-all}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/word-break
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/word-break/index.html
+++ b/packages/word-break/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.word-break | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.word-break</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/word-break">
     source on Github
   </a>
 
@@ -23,12 +23,10 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.wb-n{word-break:normal} 
+.wb-ba{word-break:break-all}
+.wb-ka{word-break:keep-all}
 
     </code>
   </pre>
@@ -37,10 +35,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.word-break@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.word-break@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/word-spacing/README.md
+++ b/packages/word-spacing/README.md
@@ -1,0 +1,38 @@
+# minions.word-spacing
+minions word-spacing classes
+
+## Module
+name: `minions.minions.word-spacing`  
+version: `0.0.4-alpha-10`  
+main/style: `word-spacing.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.word-spacing@0.0.4-alpha-10
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.word-spacing@0.0.4-alpha-10" />
+```
+
+## Code
+```css
+/*! minions.css */
+.ws-tracked{letter-spacing:.1}
+.ws-tight{letter-spacing:-.05em}
+.ws-wide{letter-spacing:.25em}
+.ws-normal{letter-spacing:normal}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/word-spacing
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/word-spacing/index.html
+++ b/packages/word-spacing/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.word-spacing | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.word-spacing</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-10/packages/word-spacing">
     source on Github
   </a>
 
@@ -23,12 +23,11 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.ws-tracked{letter-spacing:.1}
+.ws-tight{letter-spacing:-.05em}
+.ws-wide{letter-spacing:.25em}
+.ws-normal{letter-spacing:normal}
 
     </code>
   </pre>
@@ -37,10 +36,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.word-spacing@0.0.4-alpha-10</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.word-spacing@0.0.4-alpha-10" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/packages/z-index/README.md
+++ b/packages/z-index/README.md
@@ -1,0 +1,43 @@
+# minions.z-index
+minions z-index classes
+
+## Module
+name: `minions.minions.z-index`  
+version: `0.0.4-alpha-4`  
+main/style: `z-index.css`  
+
+## Installation
+npm:
+```bash
+npm install minions.z-index@0.0.4-alpha-4
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.z-index@0.0.4-alpha-4" />
+```
+
+## Code
+```css
+/*! minions.css */
+.zi-100{z-index:100}
+.zi-200{z-index:200}
+.zi-300{z-index:300}
+.zi-400{z-index:400}
+.zi-500{z-index:500}
+.zi-600{z-index:600}
+.zi-700{z-index:700}
+.zi-800{z-index:800}
+.zi-900{z-index:900}
+
+```
+
+## Source and issues
+
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/z-index
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/packages/z-index/index.html
+++ b/packages/z-index/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title>minions.z-index | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.z-index</h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-4/packages/z-index">
     source on Github
   </a>
 
@@ -23,12 +23,16 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
+/*! minions.css */
+.zi-100{z-index:100}
+.zi-200{z-index:200}
+.zi-300{z-index:300}
+.zi-400{z-index:400}
+.zi-500{z-index:500}
+.zi-600{z-index:600}
+.zi-700{z-index:700}
+.zi-800{z-index:800}
+.zi-900{z-index:900}
 
     </code>
   </pre>
@@ -37,10 +41,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.z-index@0.0.4-alpha-4</code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.z-index@0.0.4-alpha-4" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/scripts/_README.md
+++ b/scripts/_README.md
@@ -1,0 +1,33 @@
+# minions.<%= packageName %>
+<%= mod.description %>
+
+## Module
+name: `minions.<%= mod.name %>`  
+version: `<%= mod.version %>`  
+main/style: `<%= mod.style %>`  
+
+## Installation
+npm:
+```bash
+npm install minions.<%= packageName %>@<%= mod.version %>
+```
+
+browser:
+```html
+<link rel="stylesheet" href="https://unpkg.com/minions.<%= packageName %>@<%= mod.version %>" />
+```
+
+## Code
+```css
+<%= code %>
+```
+
+## Source and issues
+
+<%= mod.repository %>/tree/v<%= mod.version %>/packages/<%= packageName %>
+https://github.com/chantastic/minions.css/tree/v0.0.4-alpha-14/packages/align-content
+
+## License
+
+The MIT License (MIT)
+Copyright (c) 2016 Michael Chan

--- a/scripts/_index.html
+++ b/scripts/_index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>minions.align-items | minions.css</title>
+  <title><%= mod.name %> | minions.css</title>
   <style>
     .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
     .fs-20p{font-size:20px}
@@ -12,9 +12,9 @@
   </style>
 </head>
 <body class="ff-system-sans fs-20p m-0 px-2r">
-  <h1>minions.align-items</h1>
+  <h1>minions.<%= packageName %></h1>
 
-  <a href="https://github.com/chantastic/minions.css/tree/v0.0.4-alpah-13/packages/align-items">
+  <a href="<%= mod.repository %>/tree/v<%= mod.version %>/packages/<%= packageName %>">
     source on Github
   </a>
 
@@ -23,13 +23,7 @@
 
   <pre>
     <code>
-/*!minions.css*/
-.ai-b{align-items:baseline}
-.ai-c{align-items:center}
-.ai-fe{align-items:flex-end}
-.ai-fs{align-items:flex-start}
-.ai-s{align-items:stretch}
-
+<%= code %>
     </code>
   </pre>
 
@@ -37,10 +31,10 @@
 
   <h2>Installation</h2>
   <h4>npm</h4>
-  <code>npm install minions.align-items@0.0.4-alpah-13</code>
+  <code>npm install minions.<%= packageName %>@<%= mod.version %></code>
 
   <h4>browser</h4>
-  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.align-items@0.0.4-alpah-13" /&gt;</code>
+  <code>&lt;link rel="stylesheet" href="https://unpkg.com/minions.<%= packageName %>@<%= mod.version %>" /&gt;</code>
 
   <h2>License</h2>
   <p>The MIT License (MIT)<br />Copyright (c) 2016 Michael Chan</p>

--- a/scripts/_package_index.html
+++ b/scripts/_package_index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<title>minions.css</title>
+<style>
+  .ff-system-sans{font-family:-apple-system,BlinkMacSystemFont,sans-serif}
+  .fs-20p{font-size:20px}
+  .m-0{margin:0}
+  .px-2r{padding-right:2rem;padding-left:2rem}
+</style>
+</head>
+<body class="ff-system-sans fs-20p m-0 px-2r">
+  <h1>minions.css</h1>
+
+  <a href="https://github.com/chantastic/minions.css/" target="_blank">
+    source on Github
+  </a>
+
+  <br />
+  <hr />
+
+  <h2>Packages</h2>
+
+  <% _.forEach(packages, function(package) { %>
+    <p><a href="./packages/<%= package %>">minions.<%= package %></a></p>
+  <% }) %>
+
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-46843279-3', 'auto');
+    ga('send', 'pageview');
+
+  </script>
+</body>
+</html>

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,0 +1,37 @@
+const fs = require("fs")
+const path = require("path")
+const cons = require("consolidate")
+
+const writeFiles = ({ packageName, code, mod }) => {
+  cons["lodash"]("scripts/_README.md", {packageName, code, mod}, (_, md) =>
+    fs.writeFile(`./packages/${packageName}/README.md`, md, (_, __) =>
+      console.log(`${packageName} README.md written.`)))
+
+  cons["lodash"]("scripts/_index.html", {packageName, code, mod}, (_, html) =>
+    fs.writeFile(`./packages/${packageName}/index.html`, html, (_, __) =>
+      console.log(`${packageName} index.html written.`)))
+}
+
+fs.readdir("./packages", (err, packages) => {
+  if (err) throw err;
+  return packages.filter((file) =>
+    fs.statSync(path.join("./packages", file)).isDirectory()
+  ).forEach(packageName => {
+    if (err) throw err;
+    return fs.readFile(`./packages/${packageName}/package.json`, "utf8", (err, mod) => {
+      if (err) throw err;
+      return fs.readFile(`./packages/${packageName}/${packageName}.css`, "utf8", (err, code) => {
+        if (err) throw err;
+        return writeFiles({packageName, code, mod: JSON.parse(mod)})
+      })
+    })
+  })
+})
+
+fs.readdir("./packages", (err, packages) => {
+  if (err) throw err;
+  return cons["lodash"]("scripts/_package_index.html", {packages}, (err, html) => {
+    if (err) throw err;
+    fs.writeFile(`./index.html`, html, (_, __) => console.log(`index.html written.`))
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,6 +34,10 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+bluebird@^3.1.1:
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.6.tgz#01da8d821d87813d158967e743d5fe6c62cf8c0f"
+
 brace-expansion@^1.0.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
@@ -110,6 +114,12 @@ commander@2.8.x:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+consolidate@^0.14.5:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/consolidate/-/consolidate-0.14.5.tgz#5a25047bc76f73072667c8cb52c989888f494c63"
+  dependencies:
+    bluebird "^3.1.1"
 
 cross-spawn@^4.0.0:
   version "4.0.2"
@@ -303,7 +313,7 @@ lodash.unionwith@^4.2.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.unionwith/-/lodash.unionwith-4.6.0.tgz#74d140b5ca8146e6c643c3724f5152538d9ac1f0"
 
-lodash@^4.3.0:
+lodash@^4.17.2, lodash@^4.3.0:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 


### PR DESCRIPTION
This is a first step toward documentation.

`nom prepublish` prepares all of the documentation based each packages `README`, `package.json`, and main/style file.

Documentation is available at `https://chantastic.org/minions.css`. Individual packages are available at `./packages/package-name`

#### The script does this...

* gets package names
* generate READMEmd from file
* generate index.html from file
* generate root-level index.html